### PR TITLE
feat: add archipelago progress UIs to the character select screen

### DIFF
--- a/client/StS2AP/ArchipelagoClient.cs
+++ b/client/StS2AP/ArchipelagoClient.cs
@@ -1,31 +1,16 @@
 ﻿using Archipelago.MultiClient.Net;
-using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
 using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.Models;
 using Godot;
-using MegaCrit.Sts2.Core.Commands;
-using MegaCrit.Sts2.Core.Entities.Powers;
-using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Characters;
-using MegaCrit.Sts2.Core.Multiplayer.Game;
-using MegaCrit.Sts2.Core.Nodes.CommonUi;
-using MegaCrit.Sts2.Core.Saves;
 using StS2AP.Data;
 using StS2AP.Models;
 using StS2AP.UI;
 using StS2AP.Utils;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using static StS2AP.Data.ItemTable;
-using static System.Collections.Specialized.BitVector32;
 
 namespace StS2AP
 {

--- a/client/StS2AP/ArchipelagoClient.cs
+++ b/client/StS2AP/ArchipelagoClient.cs
@@ -601,7 +601,7 @@ namespace StS2AP
             if (slotData.ContainsKey("ascension")) settings.AscensionLevel = Convert.ToInt32(slotData["ascension"]);
             if (slotData.ContainsKey("seeded")) settings.IsSeeded = Convert.ToBoolean(slotData["seeded"]);
             if (slotData.ContainsKey("shuffle_all_cards")) settings.ShouldShuffleAllCards = Convert.ToBoolean(slotData["shuffle_all_cards"]);
-            if (slotData.ContainsKey("lock_characters")) settings.NoCharactersLocked = Convert.ToString(slotData["lock_characters"]) == "unlocked";
+            if (slotData.ContainsKey("lock_characters")) settings.NoCharactersLocked = Convert.ToInt32(slotData["lock_characters"]) == 0;
             if (slotData.ContainsKey("num_chars_goal")) settings.NumCharsGoal = Convert.ToInt32(slotData["num_chars_goal"]);
             if (slotData.ContainsKey("characters") && slotData["characters"] is System.Collections.IList charsList) settings.TotalCharacters = charsList.Count;
 

--- a/client/StS2AP/Data/LocationData.cs
+++ b/client/StS2AP/Data/LocationData.cs
@@ -28,6 +28,22 @@ namespace StS2AP.Data
                 return -1;
             }
         }
+        
+        /// <summary>
+        /// Returns whether or not the character has a "Press Start" location.
+        /// Locked characters have this location.
+        /// </summary>
+        public static bool DoesThisCharacterHavePressStartLocation(CharacterModel character)
+        {
+            // Get the location ID
+            long id = GetPressStartLocation(character);
+
+            // If the ID isn't valid, assume the location doesn't exist
+            if (id == -1) return false;
+
+            // If it's valid, see if it's in our Scouted Locations
+            return ArchipelagoClient.ScoutedLocations.ContainsKey(id);
+        }
 
         /// <summary>
         /// Returns all location IDs for Card Rewards for a given character, based on user settings.

--- a/client/StS2AP/Data/LocationData.cs
+++ b/client/StS2AP/Data/LocationData.cs
@@ -1,0 +1,137 @@
+﻿using MegaCrit.Sts2.Core.Models;
+using StS2AP.Extensions;
+using StS2AP.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StS2AP.Data
+{
+    public static class LocationData
+    {
+        /// <summary>
+        /// Get the "Press Start" Location for a given character.
+        /// 
+        /// Note: I can't seem to figure out what the location ID is for this, so it isn't used right now.
+        /// </summary>
+        public static long GetPressStartLocation(CharacterModel character)
+        {
+            try
+            {
+                return ArchipelagoClient.Session.Locations.GetLocationIdFromName("Slay the Spire II", $"{character.APName()} Press Start");
+            } catch
+            {
+                LogUtility.Error($"Could not find Press Start location for {character.APName()}");
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Card Rewards for a given character, based on user settings.
+        /// </summary>
+        /// <param name="character">The character to get Card Reward locations for.</param>
+        /// <returns>A list of location IDs for the specified character's Card Rewards.</returns>
+        public static List<long> GetCardRewardLocations(CharacterModel character)
+        {
+            // Get the number of Card Rewards based on user settings
+            var numCardRewards = ArchipelagoClient.Settings.ShouldShuffleAllCards ? ArchipelagoProgress._maxCardRewards : (ArchipelagoProgress._maxCardRewards / 2);
+            return GetLocationsByPattern($"{character.APName()} Card Reward #", numCardRewards);
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Rare Card Rewards for a given character.
+        /// </summary>
+        /// <param name="character">The character to get Rare Card Reward locations for.</param>
+        /// <returns>A list of location IDs for the specified character's Rare Card Rewards.</returns>
+        public static List<long> GetRareCardRewardLocations(CharacterModel character)
+        {
+            return GetLocationsByPattern($"{character.APName()} Rare Card Reward #", ArchipelagoProgress._maxBossRewards);
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Floorsanity
+        /// </summary>
+        /// <param name="character">The character to get Floorsanity locations for.</param>
+        /// <returns>A list of location IDs for the specified character's Floorsanity.</returns>
+        public static List<long> GetFloorsanityLocations(CharacterModel character)
+        {
+            return GetLocationsByPattern($"{character.APName()} Reached Floor #", ArchipelagoProgress._maxFloorRewards);
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Relic Rewards for a given character.
+        /// </summary>
+        /// <param name="character">The character to get Relic Reward locations for.</param>
+        /// <returns>A list of location IDs for the specified character's Relic Rewards.</returns>
+        public static List<long> GetRelicRewardLocations(CharacterModel character)
+        {
+            return GetLocationsByPattern($"{character.APName()} Relic #", ArchipelagoProgress._maxRelicRewards);
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Goldsanity for a given character.
+        /// </summary>
+        /// <param name="character">The character to get Goldsanity locations for.</param>
+        /// <returns>A list of location IDs for the specified character's gold rewards.</returns>
+        public static List<long> GetGoldsanityLocations(CharacterModel character)
+        {
+            return GetLocationsByPattern($"{character.APName()} Combat Gold #", ArchipelagoProgress._maxGoldRewards);
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Potionsanity for a given character.
+        /// </summary>
+        /// <param name="character">The character to get Potionsanity locations for.</param>
+        /// <returns>A list of location IDs for the specified character's potion drops.</returns>
+        public static List<long> GetPotionsanityLocations(CharacterModel character)
+        {
+            return GetLocationsByPattern($"{character.APName()} Potion Drop #", ArchipelagoProgress._maxPotionRewards);
+        }
+
+        /// <summary>
+        /// Returns all location IDs for Campfiresanity for a given character.
+        /// </summary>
+        /// <param name="character">The character to get Campfiresanity locations for.</param>
+        /// <returns>A list of location IDs for the specified character's campfires.</returns>
+        public static List<long> GetCampfiresanityLocations(CharacterModel character)
+        {
+            List<long> ids = new();
+            const int acts = 3;
+            const int campfiresPerAct = 2;
+            for(int a = 1; a <= acts; a++)
+            {
+                for(int c = 1; c <= campfiresPerAct; c++)
+                {
+                    try
+                    {
+                        var id = ArchipelagoClient.Session.Locations.GetLocationIdFromName("Slay the Spire II", $"{character.APName()} Act {a} Campfire {c}");
+                        ids.Add(id);
+                    } catch { }
+                }
+            }
+            return ids;
+        }
+
+        /// <summary>
+        /// Returns a list of location IDs that match a given pattern, up to a specified count.
+        /// </summary>
+        /// <param name="pattern">The pattern to match location names against, where '#' will be replaced by the index.</param>
+        /// <param name="count">The maximum number of locations to return.</param>
+        /// <returns>A list of location IDs that match the pattern. May be empty if something went wrong.</returns>
+        private static List<long> GetLocationsByPattern(string pattern, int count)
+        {
+            List<long> ids = new();
+            for(int i = 1; i <= count; i++)
+            {
+                try
+                {
+                    var id = ArchipelagoClient.Session.Locations.GetLocationIdFromName("Slay the Spire II", pattern.Replace("#", i.ToString()));
+                    ids.Add(id);
+                } catch { }
+            }
+            return ids;
+        }
+    }
+}

--- a/client/StS2AP/Data/LocationData.cs
+++ b/client/StS2AP/Data/LocationData.cs
@@ -12,21 +12,30 @@ namespace StS2AP.Data
     public static class LocationData
     {
         /// <summary>
+        /// Combines a base Location ID with a character's offset ID
+        /// </summary>
+        /// <param name="locationId">The base ID of a location</param>
+        /// <param name="character">The character to offset the location by</param>
+        /// <returns>The combined location ID.</returns>
+        /// <example>If characterOffset=1 and locationId=88, then we'd return 10088</example>
+        private static long CombineLocationAndCharacterIds(long locationId, CharacterModel character)
+        {
+            // Character offset (for locations this is zero-based, so it needs to be shifted)
+            long _characterOffset = character.GetAPLocationCharID();
+
+            // Place the character offset in the leftmost position and location ID in the rightmost 4 digits (zero-padded)
+            return (_characterOffset * 10000) + locationId;
+        }
+
+        /// <summary>
         /// Get the "Press Start" Location for a given character.
-        /// 
-        /// Note: I can't seem to figure out what the location ID is for this, so it isn't used right now.
         /// </summary>
         public static long GetPressStartLocation(CharacterModel character)
         {
-            try
-            {
-                return ArchipelagoClient.Session.Locations.GetLocationIdFromName("Slay the Spire II", $"{character.APName()} Press Start");
-            } 
-            catch
-            {
-                LogUtility.Error($"Could not find Press Start location for {character.APName()}");
-                return -1;
-            }
+            // The location ID, to be combined with the character offset
+            const long _baseLocationId = 88;
+
+            return CombineLocationAndCharacterIds(_baseLocationId, character);
         }
         
         /// <summary>
@@ -125,7 +134,11 @@ namespace StS2AP.Data
                     {
                         var id = ArchipelagoClient.Session.Locations.GetLocationIdFromName("Slay the Spire II", $"{character.APName()} Act {a} Campfire {c}");
                         ids.Add(id);
-                    } catch { }
+                    } 
+                    catch 
+                    {
+                        LogUtility.Error($"Failed to get location ID for {character.APName()} Act {a} Campfire {c}. This location will be skipped.");
+                    }
                 }
             }
             return ids;

--- a/client/StS2AP/Data/LocationData.cs
+++ b/client/StS2AP/Data/LocationData.cs
@@ -21,7 +21,8 @@ namespace StS2AP.Data
             try
             {
                 return ArchipelagoClient.Session.Locations.GetLocationIdFromName("Slay the Spire II", $"{character.APName()} Press Start");
-            } catch
+            } 
+            catch
             {
                 LogUtility.Error($"Could not find Press Start location for {character.APName()}");
                 return -1;

--- a/client/StS2AP/Extensions/CharacterModelExtensions.cs
+++ b/client/StS2AP/Extensions/CharacterModelExtensions.cs
@@ -28,5 +28,13 @@ namespace StS2AP.Extensions
         {
             return GameUtility.GetCharacterIDByName(character.APName());
         }
+
+        /// <summary>
+        /// Whether or not this character has cleared the game at least once.
+        /// </summary>
+        public static bool HasCleared(this CharacterModel character)
+        {
+            return GameUtility.HasCharacterGoaled(character.APName());
+        }
     }
 }

--- a/client/StS2AP/Extensions/CharacterModelExtensions.cs
+++ b/client/StS2AP/Extensions/CharacterModelExtensions.cs
@@ -1,0 +1,32 @@
+﻿using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using StS2AP.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static StS2AP.Data.CharTable;
+
+namespace StS2AP.Extensions
+{
+    public static class CharacterModelExtensions
+    {
+        /// <summary>
+        /// Returns the name of the character, as their name appears in the Archipelago's APWorld.
+        /// </summary>
+        /// <example>An Ironclad instance returns "Ironclad", because items for that character include "Ironclad Card Reward", "Ironclad Relic", etc.</example>
+        public static string APName(this CharacterModel character)
+        {
+            return character.GetType().Name;
+        }
+
+        /// <summary>
+        /// Gets the `APItemCharID` for this character
+        /// </summary>
+        public static APItemCharID? GetAPItemCharID(this CharacterModel character)
+        {
+            return GameUtility.GetCharacterIDByName(character.APName());
+        }
+    }
+}

--- a/client/StS2AP/Extensions/CharacterModelExtensions.cs
+++ b/client/StS2AP/Extensions/CharacterModelExtensions.cs
@@ -22,11 +22,31 @@ namespace StS2AP.Extensions
         }
 
         /// <summary>
-        /// Gets the `APItemCharID` for this character
+        /// Gets the `APItemCharID` for this character.
+        /// For Items, this is one-based.
         /// </summary>
         public static APItemCharID? GetAPItemCharID(this CharacterModel character)
         {
             return GameUtility.GetCharacterIDByName(character.APName());
+        }
+
+        /// <summary>
+        /// Gets the Location ID offset used for this character.
+        /// For Locations, this is zero-based.
+        /// </summary>
+        public static long GetAPLocationCharID(this CharacterModel character)
+        {
+            var charId = character.GetAPItemCharID();
+            if (charId.HasValue)
+            {
+                return (long)charId.Value - 1;
+            }
+            else
+            {
+                var msg = $"Character {character.APName()} does not have a valid APItemCharID. It's likely that a new character was added that we aren't handling properly.";
+                LogUtility.Error(msg);
+                throw new NullReferenceException(msg);
+            }
         }
 
         /// <summary>

--- a/client/StS2AP/Models/ArchipelagoProgress.cs
+++ b/client/StS2AP/Models/ArchipelagoProgress.cs
@@ -25,6 +25,11 @@ namespace StS2AP.Models
         public const int _maxCardRewards = 20;
 
         /// <summary>
+        /// The maximum possible number of Rare Card Rewards. One for each Boss w/ Rewards.
+        /// </summary>
+        public const int _maxRareCardRewards = 2;
+
+        /// <summary>
         /// The maximum possible number of Relic Rewards that a player could have replaced with AP locations, regardless of settings.
         /// </summary>
         public const int _maxRelicRewards = 10;
@@ -42,6 +47,16 @@ namespace StS2AP.Models
         public const int _maxPotionRewards = 9;
 
         public const int _maxBossRewards = 3;
+
+        /// <summary>
+        /// The number of floor rewards in floorsanity
+        /// </summary>
+        public const int _maxFloorRewards = 47;
+
+        /// <summary>
+        /// Maximum possible number of Campfire Rewards that a player could find.
+        /// </summary>
+        public const int _maxCampfireChecks = 6;
 
         #region Per-Run Tracker
 

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -13,7 +13,7 @@ namespace StS2AP.Patches
     public static class Patches_APProgressOnCharSelect
     {
         /// <summary>
-        /// When the Player selects a character, update the Archipelago Progres panel with information on that character
+        /// When the Player selects a character, update the Archipelago Progres panels with information on that character
         /// </summary>
         [HarmonyPatch(typeof(NCharacterSelectScreen))]
         public static class UpdateCharTrackerUI
@@ -23,8 +23,10 @@ namespace StS2AP.Patches
             public static void Postfix(NCharacterSelectScreen __instance, NCharacterSelectButton charSelectButton, CharacterModel characterModel)
             {
                 ArchipelagoCharTrackerUI.Show();
+                ArchipelagoGoalTrackerUI.Show();
                 UpdateReceivedItems(characterModel);
                 UpdateCheckedLocations(characterModel);
+                ArchipelagoGoalTrackerUI.UpdateGoalProgress();
             }
 
             /// <summary>

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -3,13 +3,9 @@ using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using StS2AP.Data;
 using StS2AP.Extensions;
+using StS2AP.Models;
 using StS2AP.UI;
-using StS2AP.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using StS2AP.UI.Components;
 
 namespace StS2AP.Patches
 {
@@ -24,6 +20,91 @@ namespace StS2AP.Patches
             [HarmonyPatch("SelectCharacter")]
             [HarmonyPostfix]
             public static void Postfix(NCharacterSelectScreen __instance, NCharacterSelectButton charSelectButton, CharacterModel characterModel)
+            {
+                UpdateReceivedItems(characterModel);
+                UpdateCheckedLocations(characterModel);
+            }
+
+            /// <summary>
+            /// Updates the Found/Checked Locations in the UI for the currently selected character.
+            /// Shows/Hides items based on what settings you are using for this run.
+            /// </summary>
+            private static void UpdateCheckedLocations(CharacterModel character)
+            {
+                // Update Card Locations
+                var cardLocations = LocationData.GetCardRewardLocations(character);
+                SetCheckedLocation(ArchipelagoCharTrackerUI.CardChecks, cardLocations, ArchipelagoProgress._maxCardRewards / (ArchipelagoClient.Settings.ShouldShuffleAllCards ? 1 : 2));
+
+                // Update Rare Card Locations
+                var rareCardLocations = LocationData.GetRareCardRewardLocations(character);
+                SetCheckedLocation(ArchipelagoCharTrackerUI.RareCardChecks, rareCardLocations, ArchipelagoProgress._maxRareCardRewards);
+
+                // Update Relic Locations
+                var relicLocations = LocationData.GetRelicRewardLocations(character);
+                SetCheckedLocation(ArchipelagoCharTrackerUI.RelicChecks, relicLocations, ArchipelagoProgress._maxRelicRewards);
+
+                // Update Floorsanity Locations
+                if(ArchipelagoClient.Settings.Floorsanity)
+                {
+                    var floorLocations = LocationData.GetFloorsanityLocations(character);
+                    SetCheckedLocation(ArchipelagoCharTrackerUI.FloorsanityChecks, floorLocations, ArchipelagoProgress._maxFloorRewards);
+                }
+
+                // Update Campfiresanity Locations
+                if(ArchipelagoClient.Settings.CampfireSanity)
+                {
+                    var campfireLocations = LocationData.GetCampfiresanityLocations(character);
+                    SetCheckedLocation(ArchipelagoCharTrackerUI.CampfiresanityChecks, campfireLocations, ArchipelagoProgress._maxCampfireChecks);
+                }
+
+                // Update Goldsanity Locations
+                if(ArchipelagoClient.Settings.GoldSanity)
+                {
+                    var goldLocations = LocationData.GetGoldsanityLocations(character);
+                    SetCheckedLocation(ArchipelagoCharTrackerUI.GoldsanityChecks, goldLocations, ArchipelagoProgress._maxGoldRewards);
+                }
+
+                // Update Potionsanity Locations
+                if(ArchipelagoClient.Settings.PotionSanity)
+                {
+                    var potionLocations = LocationData.GetPotionsanityLocations(character);
+                    SetCheckedLocation(ArchipelagoCharTrackerUI.PotionsanityChecks, potionLocations, ArchipelagoProgress._maxPotionRewards);
+                }
+
+                // Update Press Start State
+                var hasStarted = ArchipelagoClient.CheckedLocations.Contains(LocationData.GetPressStartLocation(character));
+                ArchipelagoCharTrackerUI.PressStartCheck?.SetText(hasStarted ? "[green][sine]✓[/sine][/green]" : "—");
+
+                // Update Goal State
+                ArchipelagoCharTrackerUI.ClearedCheck?.SetText(character.HasCleared() ? "[green][sine]✓[/sine][/green]" : "—");
+            }
+
+            /// <summary>
+            /// Updates the text of the given ItemCountLabel to show how many of the given locations have
+            /// been checked off by the player, out of the total number of those locations for this character.
+            /// </summary>
+            /// <param name="component">The UI component to update.</param>
+            /// <param name="locations">The list of locations to check against what we've found so far.</param>
+            /// <param name="totalCount">The total number of locations for this character.</param>
+            private static void SetCheckedLocation(ItemCountLabel? component, List<long> locations, int totalCount)
+            {
+                var checkedLocations = ArchipelagoClient.CheckedLocations.Intersect(locations).ToList();
+                var label = $"({checkedLocations.Count} / {totalCount})";
+
+                // If the user has found all of the checks, mark the label as green/sine to celebrate!
+                if (checkedLocations.Count >= totalCount)
+                {
+                    label = $"[green][sine]{label}[/sine][/green]";
+                }
+
+                component?.SetText(label);
+            }
+
+            /// <summary>
+            /// Updates the Received Items in the UI for the currently selected character, 
+            /// including gold rewards, card/relic/potion rewards, and progressive smith/rest levels.
+            /// </summary>
+            private static void UpdateReceivedItems(CharacterModel characterModel)
             {
                 // Get Character ID
                 var id = characterModel.GetAPItemCharID();

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -1,0 +1,97 @@
+﻿using HarmonyLib;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using StS2AP.Data;
+using StS2AP.Extensions;
+using StS2AP.UI;
+using StS2AP.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StS2AP.Patches
+{
+    public static class Patches_APProgressOnCharSelect
+    {
+        /// <summary>
+        /// When the Player selects a character, update the Archipelago Progres panel with information on that character
+        /// </summary>
+        [HarmonyPatch(typeof(NCharacterSelectScreen))]
+        public static class UpdateCharTrackerUI
+        {
+            [HarmonyPatch("SelectCharacter")]
+            [HarmonyPostfix]
+            public static void Postfix(NCharacterSelectScreen __instance, NCharacterSelectButton charSelectButton, CharacterModel characterModel)
+            {
+                // Get Character ID
+                var id = characterModel.GetAPItemCharID();
+                LogUtility.Info($"Selected Character: {characterModel.APName()}, AP Char ID: {(id.HasValue ? id.Value.ToString() : "null")}");
+
+                // If (somehow) the character ID is null, stop
+                if (!id.HasValue) return;
+
+                // Update Gold Rewards
+                LogUtility.Info($"Checking for gold rewards for character ID {id.Value}");
+                if (ArchipelagoClient.Progress.GoldReceived.TryGetValue(id.Value, out int gold))
+                {
+                    LogUtility.Info($"Found gold rewards for character ID {id.Value}: {gold}");
+                    ArchipelagoCharTrackerUI.GoldRewards?.SetText(gold.ToString());
+                }
+                else
+                {
+                    LogUtility.Error($"No gold rewards found for character ID {id.Value}");
+                    ArchipelagoCharTrackerUI.GoldRewards?.SetText("0");
+                }
+
+                // Update Progressive Smiths/Rests
+                ArchipelagoCharTrackerUI.ProgressiveRestLabel?.SetText($"({ArchipelagoClient.Progress.MaxRestLevel(id.Value) ?? 0} / 3)");
+                ArchipelagoCharTrackerUI.ProgressiveSmithLabel?.SetText($"({ArchipelagoClient.Progress.MaxSmithLevel(id.Value) ?? 0} / 3)");
+
+                // Count Card/Relic/Potion/Progressive Rewards
+                var itemCounts = ArchipelagoClient.Progress.AllReceivedItems
+                    .Where(i => i.Item.GetStSCharID() == id.Value)
+                    .GroupBy(i => i.Item.GetRawItemID())
+                    .ToDictionary(
+                        g => g.Key,
+                        g => g.Count());
+
+                // Update Card Rewards
+                if (itemCounts.TryGetValue(ItemTable.APItem.CardReward, out int cardCount))
+                {
+                    ArchipelagoCharTrackerUI.CardRewards?.SetText(cardCount.ToString());
+                }
+                else
+                {
+                    ArchipelagoCharTrackerUI.CardRewards?.SetText("0");
+                }
+
+                // Update Rare Card Rewards
+                if (itemCounts.TryGetValue(ItemTable.APItem.RareCardReward, out int rareCardCount))
+                {
+                    ArchipelagoCharTrackerUI.RareCardRewards?.SetText(rareCardCount.ToString());
+                }
+                else
+                {
+                    ArchipelagoCharTrackerUI.RareCardRewards?.SetText("0");
+                }
+
+                // Update Relic Rewards (both regular and boss relics)
+                var relicCount = (itemCounts.TryGetValue(ItemTable.APItem.Relic, out int relicStandard) ? relicStandard : 0) +
+                                 (itemCounts.TryGetValue(ItemTable.APItem.BossRelic, out int relicBoss) ? relicBoss : 0);
+                ArchipelagoCharTrackerUI.RelicRewards?.SetText(relicCount.ToString());
+
+                // Update Potion Rewards
+                if (itemCounts.TryGetValue(ItemTable.APItem.Potion, out int potionCount))
+                {
+                    ArchipelagoCharTrackerUI.PotionRewards?.SetText(potionCount.ToString());
+                }
+                else
+                {
+                    ArchipelagoCharTrackerUI.PotionRewards?.SetText("0");
+                }
+            }
+        }
+    }
+}

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Godot;
+using HarmonyLib;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using StS2AP.Data;
@@ -11,22 +12,6 @@ namespace StS2AP.Patches
 {
     public static class Patches_APProgressOnCharSelect
     {
-        /// <summary>
-        /// Hides the Archipelago Progress Tracker UI when the player leaves the Character Select screen
-        /// </summary>
-        [HarmonyPatch(typeof(NCharacterSelectScreen))]
-        public static class RemoveCharTrackerOnRunStart
-        {
-            [HarmonyPatch("OnSubmenuClosed")]
-            [HarmonyPostfix]
-            public static void Postfix()
-            {
-                LogUtility.Info("MADE IT TO SUBMENU POSTFIX");
-                // Get rid of the tracker UI
-                ArchipelagoCharTrackerUI.RemoveUI();
-            }
-        }
-
         /// <summary>
         /// When the Player selects a character, update the Archipelago Progres panel with information on that character
         /// </summary>
@@ -61,28 +46,28 @@ namespace StS2AP.Patches
                 SetCheckedLocation(ArchipelagoCharTrackerUI.RelicChecks, relicLocations, ArchipelagoProgress._maxRelicRewards);
 
                 // Update Floorsanity Locations
-                if(ArchipelagoClient.Settings.Floorsanity)
+                if (ArchipelagoClient.Settings.Floorsanity)
                 {
                     var floorLocations = LocationData.GetFloorsanityLocations(character);
                     SetCheckedLocation(ArchipelagoCharTrackerUI.FloorsanityChecks, floorLocations, ArchipelagoProgress._maxFloorRewards);
                 }
 
                 // Update Campfiresanity Locations
-                if(ArchipelagoClient.Settings.CampfireSanity)
+                if (ArchipelagoClient.Settings.CampfireSanity)
                 {
                     var campfireLocations = LocationData.GetCampfiresanityLocations(character);
                     SetCheckedLocation(ArchipelagoCharTrackerUI.CampfiresanityChecks, campfireLocations, ArchipelagoProgress._maxCampfireChecks);
                 }
 
                 // Update Goldsanity Locations
-                if(ArchipelagoClient.Settings.GoldSanity)
+                if (ArchipelagoClient.Settings.GoldSanity)
                 {
                     var goldLocations = LocationData.GetGoldsanityLocations(character);
                     SetCheckedLocation(ArchipelagoCharTrackerUI.GoldsanityChecks, goldLocations, ArchipelagoProgress._maxGoldRewards);
                 }
 
                 // Update Potionsanity Locations
-                if(ArchipelagoClient.Settings.PotionSanity)
+                if (ArchipelagoClient.Settings.PotionSanity)
                 {
                     var potionLocations = LocationData.GetPotionsanityLocations(character);
                     SetCheckedLocation(ArchipelagoCharTrackerUI.PotionsanityChecks, potionLocations, ArchipelagoProgress._maxPotionRewards);

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -13,7 +13,7 @@ namespace StS2AP.Patches
     public static class Patches_APProgressOnCharSelect
     {
         /// <summary>
-        /// When the Player selects a character, update the Archipelago Progres panels with information on that character
+        /// When the Player selects a character, update the Archipelago Progress panels with information on that character
         /// </summary>
         [HarmonyPatch(typeof(NCharacterSelectScreen))]
         public static class UpdateCharTrackerUI

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -72,8 +72,11 @@ namespace StS2AP.Patches
                 }
 
                 // Update Press Start State
-                var hasStarted = ArchipelagoClient.CheckedLocations.Contains(LocationData.GetPressStartLocation(character));
-                ArchipelagoCharTrackerUI.PressStartCheck?.SetText(hasStarted ? "[green][sine]✓[/sine][/green]" : "—");
+                if(!ArchipelagoClient.Settings.NoCharactersLocked)
+                {
+                    var hasStarted = ArchipelagoClient.CheckedLocations.Contains(LocationData.GetPressStartLocation(character));
+                    ArchipelagoCharTrackerUI.PressStartCheck?.SetText(hasStarted ? "[green][sine]✓[/sine][/green]" : "—");
+                }
 
                 // Update Goal State
                 ArchipelagoCharTrackerUI.ClearedCheck?.SetText(character.HasCleared() ? "[green][sine]✓[/sine][/green]" : "—");

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -12,6 +12,22 @@ namespace StS2AP.Patches
     public static class Patches_APProgressOnCharSelect
     {
         /// <summary>
+        /// Hides the Archipelago Progress Tracker UI when the player leaves the Character Select screen
+        /// </summary>
+        [HarmonyPatch(typeof(NCharacterSelectScreen))]
+        public static class RemoveCharTrackerOnRunStart
+        {
+            [HarmonyPatch("OnSubmenuClosed")]
+            [HarmonyPostfix]
+            public static void Postfix()
+            {
+                LogUtility.Info("MADE IT TO SUBMENU POSTFIX");
+                // Get rid of the tracker UI
+                ArchipelagoCharTrackerUI.RemoveUI();
+            }
+        }
+
+        /// <summary>
         /// When the Player selects a character, update the Archipelago Progres panel with information on that character
         /// </summary>
         [HarmonyPatch(typeof(NCharacterSelectScreen))]
@@ -21,6 +37,7 @@ namespace StS2AP.Patches
             [HarmonyPostfix]
             public static void Postfix(NCharacterSelectScreen __instance, NCharacterSelectButton charSelectButton, CharacterModel characterModel)
             {
+                ArchipelagoCharTrackerUI.Show();
                 UpdateReceivedItems(characterModel);
                 UpdateCheckedLocations(characterModel);
             }
@@ -29,7 +46,7 @@ namespace StS2AP.Patches
             /// Updates the Found/Checked Locations in the UI for the currently selected character.
             /// Shows/Hides items based on what settings you are using for this run.
             /// </summary>
-            private static void UpdateCheckedLocations(CharacterModel character)
+            public static void UpdateCheckedLocations(CharacterModel character)
             {
                 // Update Card Locations
                 var cardLocations = LocationData.GetCardRewardLocations(character);
@@ -72,14 +89,13 @@ namespace StS2AP.Patches
                 }
 
                 // Update Press Start State
-                if(!ArchipelagoClient.Settings.NoCharactersLocked)
-                {
-                    var hasStarted = ArchipelagoClient.CheckedLocations.Contains(LocationData.GetPressStartLocation(character));
-                    ArchipelagoCharTrackerUI.PressStartCheck?.SetText(hasStarted ? "[green][sine]✓[/sine][/green]" : "—");
-                }
+                var hasPressStart = LocationData.DoesThisCharacterHavePressStartLocation(character);
+                var hasStarted = ArchipelagoClient.CheckedLocations.Contains(LocationData.GetPressStartLocation(character));
+                var pressStartText = hasPressStart ? (hasStarted ? "[green][sine]✓[/sine][/green]" : "[red]—[/red]") : "N/A";
+                ArchipelagoCharTrackerUI.PressStartCheck?.SetText(pressStartText);
 
                 // Update Goal State
-                ArchipelagoCharTrackerUI.ClearedCheck?.SetText(character.HasCleared() ? "[green][sine]✓[/sine][/green]" : "—");
+                ArchipelagoCharTrackerUI.ClearedCheck?.SetText(character.HasCleared() ? "[green][sine]✓[/sine][/green]" : "[red]—[/red]");
             }
 
             /// <summary>
@@ -107,7 +123,7 @@ namespace StS2AP.Patches
             /// Updates the Received Items in the UI for the currently selected character, 
             /// including gold rewards, card/relic/potion rewards, and progressive smith/rest levels.
             /// </summary>
-            private static void UpdateReceivedItems(CharacterModel characterModel)
+            public static void UpdateReceivedItems(CharacterModel characterModel)
             {
                 // Get Character ID
                 var id = characterModel.GetAPItemCharID();

--- a/client/StS2AP/Patches/Patches_HookRunStart.cs
+++ b/client/StS2AP/Patches/Patches_HookRunStart.cs
@@ -30,6 +30,7 @@ namespace StS2AP.Patches
             {
                 // Get rid of the tracker UI
                 ArchipelagoCharTrackerUI.RemoveUI();
+                ArchipelagoGoalTrackerUI.RemoveUI();
 
                 // Grab a reference to the current player
                 GameUtility.CurrentPlayer = __result;
@@ -60,6 +61,7 @@ namespace StS2AP.Patches
             {
                 // Get rid of the tracker UI
                 ArchipelagoCharTrackerUI.RemoveUI();
+                ArchipelagoGoalTrackerUI.RemoveUI();
             }
         }
 

--- a/client/StS2AP/Patches/Patches_HookRunStart.cs
+++ b/client/StS2AP/Patches/Patches_HookRunStart.cs
@@ -5,6 +5,7 @@ using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Unlocks;
+using StS2AP.UI;
 using StS2AP.Utils;
 using System;
 using System.Linq;
@@ -25,6 +26,9 @@ namespace StS2AP.Patches
             [HarmonyPostfix]
             public static void Postfix(Player __result)
             {
+                // Get rid of the tracker UI
+                ArchipelagoCharTrackerUI.RemoveUI();
+
                 // Grab a reference to the current player
                 GameUtility.CurrentPlayer = __result;
 

--- a/client/StS2AP/Patches/Patches_HookRunStart.cs
+++ b/client/StS2AP/Patches/Patches_HookRunStart.cs
@@ -4,11 +4,13 @@ using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes;
 using MegaCrit.Sts2.Core.Runs;
+using MegaCrit.Sts2.Core.Saves.Runs;
 using MegaCrit.Sts2.Core.Unlocks;
 using StS2AP.UI;
 using StS2AP.Utils;
 using System;
 using System.Linq;
+using static Godot.HttpRequest;
 
 namespace StS2AP.Patches
 {
@@ -44,6 +46,20 @@ namespace StS2AP.Patches
 
                 // Clear buffers
                 ArchipelagoClient.Progress.UsedItems.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Similar to `OnRunStart` but only happens on loading a run. We don't have to initialize anything, but we still need to do some work.
+        /// </summary>
+        [HarmonyPatch(typeof(Player), nameof(Player.FromSerializable), new Type[] { typeof(SerializablePlayer) })]
+        public static class OnRunLoad
+        {
+            [HarmonyPostfix]
+            public static void Postfix()
+            {
+                // Get rid of the tracker UI
+                ArchipelagoCharTrackerUI.RemoveUI();
             }
         }
 

--- a/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
+++ b/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
@@ -123,5 +123,30 @@ namespace StS2AP.Patches
                 __instance.GetNode<NBackButton>("BackButton").Visible = false;
             }
         }
+
+        /// <summary>
+        /// Injects the Archipelago Progress Tracker panel when the Character Select screen opens,
+        /// and removes it when the screen closes. Keeping injection in OnSubmenuOpened (rather than
+        /// _Ready) ensures the CanvasLayer is created after the scene tree is fully set up.
+        /// </summary>
+        [HarmonyPatch(typeof(NCharacterSelectScreen))]
+        public static class CharTrackerPanelPatches
+        {
+            /// <summary>Show the tracker panel as soon as the screen becomes active.</summary>
+            [HarmonyPatch(nameof(NCharacterSelectScreen.OnSubmenuOpened))]
+            [HarmonyPostfix]
+            static void OnOpened(NCharacterSelectScreen __instance)
+            {
+                ArchipelagoCharTrackerUI.InjectUI();
+            }
+
+            /// <summary>Remove the tracker panel when the player leaves the Character Select screen.</summary>
+            [HarmonyPatch(nameof(NCharacterSelectScreen.OnSubmenuClosed))]
+            [HarmonyPostfix]
+            static void OnClosed(NCharacterSelectScreen __instance)
+            {
+                ArchipelagoCharTrackerUI.RemoveUI();
+            }
+        }
     }
 }

--- a/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
+++ b/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
@@ -144,11 +144,19 @@ namespace StS2AP.Patches
                 NCharacterSelectButton firstButton = charButtonContainer.GetChild<NCharacterSelectButton>(0);
                 CharacterModel character = firstButton.Character;
 
-                // Setup the character tracker UI (top-left)
+                // Setup the character tracker UI
                 ArchipelagoCharTrackerUI.InjectUI(character);
 
-                // Setup the goal tracker UI (bottom-left)
+                // Setup the goal tracker UI (initial goal text needs to be ever-so-slightly delayed or the text is TINY)
                 ArchipelagoGoalTrackerUI.InjectUI();
+                var sceneTree = Engine.GetMainLoop() as SceneTree;
+                if (sceneTree != null)
+                {
+                    sceneTree.CreateTimer(0.2f).Timeout += () =>
+                    {
+                        ArchipelagoGoalTrackerUI.UpdateGoalProgress();
+                    };
+                }
             }
 
             /// <summary>Remove the tracker panels when the player leaves the Character Select screen.</summary>

--- a/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
+++ b/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
@@ -134,7 +134,7 @@ namespace StS2AP.Patches
         [HarmonyPatch(typeof(NCharacterSelectScreen))]
         public static class CharTrackerPanelPatches
         {
-            /// <summary>Show the tracker panel as soon as the screen becomes active.</summary>
+            /// <summary>Show the tracker panels as soon as the screen becomes active.</summary>
             [HarmonyPatch(nameof(NCharacterSelectScreen.OnSubmenuOpened))]
             [HarmonyPostfix]
             static void OnOpened(NCharacterSelectScreen __instance)
@@ -144,16 +144,20 @@ namespace StS2AP.Patches
                 NCharacterSelectButton firstButton = charButtonContainer.GetChild<NCharacterSelectButton>(0);
                 CharacterModel character = firstButton.Character;
 
-                // Setup the UI
+                // Setup the character tracker UI (top-left)
                 ArchipelagoCharTrackerUI.InjectUI(character);
+
+                // Setup the goal tracker UI (bottom-left)
+                ArchipelagoGoalTrackerUI.InjectUI();
             }
 
-            /// <summary>Remove the tracker panel when the player leaves the Character Select screen.</summary>
+            /// <summary>Remove the tracker panels when the player leaves the Character Select screen.</summary>
             [HarmonyPatch(nameof(NCharacterSelectScreen.OnSubmenuClosed))]
             [HarmonyPostfix]
             static void OnClosed(NCharacterSelectScreen __instance)
             {
                 ArchipelagoCharTrackerUI.RemoveUI();
+                ArchipelagoGoalTrackerUI.RemoveUI();
             }
         }
     }

--- a/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
+++ b/client/StS2AP/Patches/Patches_MainMenuBehavior.cs
@@ -1,4 +1,6 @@
-﻿using HarmonyLib;
+﻿using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
@@ -137,7 +139,13 @@ namespace StS2AP.Patches
             [HarmonyPostfix]
             static void OnOpened(NCharacterSelectScreen __instance)
             {
-                ArchipelagoCharTrackerUI.InjectUI();
+                // Find the first character on the screen
+                Control charButtonContainer = __instance.GetNode<Control>("CharSelectButtons/ButtonContainer");
+                NCharacterSelectButton firstButton = charButtonContainer.GetChild<NCharacterSelectButton>(0);
+                CharacterModel character = firstButton.Character;
+
+                // Setup the UI
+                ArchipelagoCharTrackerUI.InjectUI(character);
             }
 
             /// <summary>Remove the tracker panel when the player leaves the Character Select screen.</summary>

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -1,10 +1,12 @@
 ﻿using Godot;
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using StS2AP.Data;
 using StS2AP.Models;
 using StS2AP.UI.Components;
 using StS2AP.Utils;
 using System;
+using static StS2AP.Patches.Patches_APProgressOnCharSelect;
 
 namespace StS2AP.UI
 {
@@ -515,11 +517,8 @@ namespace StS2AP.UI
             }
 
             // Press Start Counter
-            if(!ArchipelagoClient.Settings.NoCharactersLocked)
-            {
-                PressStartCheck = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
-                AddCheckRow(PressStartCheck);
-            }
+            PressStartCheck = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
+            AddCheckRow(PressStartCheck);
 
             // Slayed the Spire Counter
             ClearedCheck = new ItemCountLabel("res://images/relics/pantograph.png", "—", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");
@@ -554,9 +553,6 @@ namespace StS2AP.UI
             // Progressive Smith Total
             ProgressiveSmithLabel = new ItemCountLabel("res://images/relics/whetstone.png", "(0 / 3)", tooltipTitle: "Progressive Smiths", tooltipDescription: "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at.");
             AddItemRow(ProgressiveSmithLabel);
-
-            // Start visible — it will be shown/hidden by the patch hooks
-            root.Visible = true;
 
             return root;
         }

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -1,6 +1,7 @@
 ﻿using Godot;
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using StS2AP.Models;
 using StS2AP.UI.Components;
 using StS2AP.Utils;
 using System;
@@ -85,10 +86,10 @@ namespace StS2AP.UI
         public static ItemCountLabel? CampfiresanityChecks { get; private set; }
 
         /// <summary>Tracks whether the "Press Start" check has been earned.</summary>
-        public static ItemCountLabel? PressStartChecks { get; private set; }
+        public static ItemCountLabel? PressStartCheck { get; private set; }
 
         /// <summary>Tracks whether the "Slayed the Spire" check has been earned.</summary>
-        public static ItemCountLabel? ClearedChecks { get; private set; }
+        public static ItemCountLabel? ClearedCheck { get; private set; }
 
         // ── AP Item labels (right list) ───────────────────────────────────────────
 
@@ -138,9 +139,7 @@ namespace StS2AP.UI
         private static readonly Color PanelBgColor = new Color(0.10f, 0.10f, 0.13f, 0.5f);
 
         // CanvasLayer rendering order.
-        // Kept low (below 100) so the game's own UI layers — connection UI (100), notification UI (101),
-        // reward UI (110), and the tooltip system — all render on top of this panel.
-        private const int CanvasLayerIndex = 10;
+        private const int CanvasLayerIndex = 0;
 
         // Maximum rows per sub-column before wrapping to a new column
         private const int MaxRowsPerColumn = 6;
@@ -236,8 +235,8 @@ namespace StS2AP.UI
                 PotionsanityChecks   = null;
                 GoldsanityChecks     = null;
                 CampfiresanityChecks = null;
-                PressStartChecks     = null;
-                ClearedChecks        = null;
+                PressStartCheck     = null;
+                ClearedCheck        = null;
                 CardRewards          = null;
                 RareCardRewards      = null;
                 RelicRewards         = null;
@@ -488,28 +487,40 @@ namespace StS2AP.UI
             AddCheckRow(RelicChecks);
 
             // Floorsanity Checks Counter (Note: When the Winged Boots are in main, we should use that relic here instead)
-            FloorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(0 / 0)", tooltipTitle: "Floorsanity Checks", tooltipDescription: "The number of AP Checks sent for each floor reached");
-            AddCheckRow(FloorsanityChecks);
+            if(ArchipelagoClient.Settings.Floorsanity)
+            {
+                FloorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(0 / 0)", tooltipTitle: "Floorsanity Checks", tooltipDescription: "The number of AP Checks sent for each floor reached");
+                AddCheckRow(FloorsanityChecks);
+            }
 
             // Potionsanity Checks Counter
-            PotionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(0 / 0)", tooltipTitle: "Potionsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Potion Rewards");
-            AddCheckRow(PotionsanityChecks);
+            if(ArchipelagoClient.Settings.PotionSanity)
+            {
+                PotionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(0 / 0)", tooltipTitle: "Potionsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Potion Rewards");
+                AddCheckRow(PotionsanityChecks);
+            }
 
             // Goldsanity Checks Counter
-            GoldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(0 / 0)", tooltipTitle: "Goldsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Gold Rewards");
-            AddCheckRow(GoldsanityChecks);
+            if(ArchipelagoClient.Settings.GoldSanity)
+            {
+                GoldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(0 / 0)", tooltipTitle: "Goldsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Gold Rewards");
+                AddCheckRow(GoldsanityChecks);
+            }
 
             // Campfiresanity Checks Counter
-            CampfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(0 / 0)", tooltipTitle: "Campfiresanity Checks", tooltipDescription: "The number of AP Checks found from Rest Sites");
-            AddCheckRow(CampfiresanityChecks);
+            if(ArchipelagoClient.Settings.CampfireSanity)
+            {
+                CampfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(0 / 0)", tooltipTitle: "Campfiresanity Checks", tooltipDescription: "The number of AP Checks found from Rest Sites");
+                AddCheckRow(CampfiresanityChecks);
+            }
 
             // Press Start Counter
-            PressStartChecks = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
-            AddCheckRow(PressStartChecks);
+            PressStartCheck = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
+            AddCheckRow(PressStartCheck);
 
             // Slayed the Spire Counter
-            ClearedChecks = new ItemCountLabel("res://images/relics/pantograph.png", "—", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");
-            AddCheckRow(ClearedChecks);
+            ClearedCheck = new ItemCountLabel("res://images/relics/pantograph.png", "—", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");
+            AddCheckRow(ClearedCheck);
 
             // ── AP Items ──────────────────────────────────────────────────────
 

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -2,11 +2,7 @@
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
-using StS2AP.Data;
-using StS2AP.Models;
 using StS2AP.UI.Components;
-using StS2AP.Utils;
-using System;
 using static StS2AP.Patches.Patches_APProgressOnCharSelect;
 
 namespace StS2AP.UI
@@ -14,11 +10,6 @@ namespace StS2AP.UI
     /// <summary>
     /// Static class that creates and manages the Archipelago Progress Tracker panel
     /// on the Character Select screen.
-    ///
-    /// The panel is positioned on the left side of the screen, offset ~200 logical
-    /// pixels from the left edge and near the top of the viewport — intentionally
-    /// mirroring the vertical position and size of the game's own InfoPanel
-    /// (<see cref="NCharacterSelectScreen"/> node: "InfoPanel").
     ///
     /// Injected via <see cref="CharTrackerInjectionPatch"/> which postfixes
     /// <see cref="NCharacterSelectScreen.OnSubmenuOpened"/> and
@@ -61,11 +52,7 @@ namespace StS2AP.UI
 
         #endregion
 
-        #region ItemCountLabel References
-
-        // ── AP Check labels (left list) ───────────────────────────────────────────
-        // Each label can be updated at runtime via its SetText() method, e.g.:
-        //   ArchipelagoCharTrackerUI.CardChecks?.SetText("(15 / 45)");
+        #region AP Location Labels
 
         /// <summary>Tracks how many Card Reward AP Checks have been found.</summary>
         public static ItemCountLabel? CardChecks { get; private set; }
@@ -94,7 +81,9 @@ namespace StS2AP.UI
         /// <summary>Tracks whether the "Slayed the Spire" check has been earned.</summary>
         public static ItemCountLabel? ClearedCheck { get; private set; }
 
-        // ── AP Item labels (right list) ───────────────────────────────────────────
+        #endregion
+
+        #region AP Item Labels
 
         /// <summary>Tracks the number of Card Rewards received from the multiworld.</summary>
         public static ItemCountLabel? CardRewards { get; private set; }
@@ -199,8 +188,8 @@ namespace StS2AP.UI
                 _canvasLayer.AddChild(_rootPanel);
                 root.AddChild(_canvasLayer);
 
-                // SetContent() must be called after the node is in the tree — MegaRichTextLabel._Ready()
-                // resets font size overrides on tree entry, so we apply ours immediately after.
+                /// SetContent() must be called after the node is in the tree — MegaRichTextLabel._Ready()
+                /// resets font size overrides on tree entry, so we apply ours immediately after.
                 SetContent("[gold]Checks Found[/gold]                                 [gold]Received Items[/gold]");
 
                 LogUtility.Success("[CharTracker] Archipelago char-tracker UI injected successfully");
@@ -325,9 +314,9 @@ namespace StS2AP.UI
         #region UI Construction
 
         /// <summary>
-        /// Builds the entire panel hierarchy from scratch (no Godot editor scenes available).
+        /// Builds the entire panel hierarchy from scratch.
         ///
-        /// Layout (left-anchored):
+        /// Layout:
         /// <code>
         ///   Control (root, FullRect)
         ///     └─ PanelContainer  ← semi-transparent background, fixed size, top-left anchor
@@ -343,30 +332,25 @@ namespace StS2AP.UI
         /// <param name="character">The initial character to display information for</param>
         private static Control CreateUI(CharacterModel character)
         {
-            // ── Root ──────────────────────────────────────────────────────────────────
-            // Full-rect so anchors/offsets work relative to the full viewport.
+            // Create the Root
             var root = new Control();
             root.Name = "ArchipelagoCharTrackerUI";
             root.SetAnchorsPreset(Control.LayoutPreset.FullRect);
             // Pass all mouse events through so we don't block game input
             root.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-            // ── Panel ─────────────────────────────────────────────────────────────────
-            // Anchored to the top-left corner to sit alongside the game's InfoPanel.
-            // PanelLeftOffset pushes us ~200 px from the left edge so the panel doesn't
-            // overlap the character buttons, mirroring the InfoPanel's horizontal position.
+            // Setup the Panel
             var panel = new PanelContainer();
             panel.Name = "CharTrackerPanel";
             panel.CustomMinimumSize = new Vector2(PanelWidth, PanelHeight);
 
-            // Position: anchor top-left, then shift right by PanelLeftOffset.
+            // Panel Anchors
             panel.AnchorLeft   = 0f;
             panel.AnchorRight  = 0f;
             panel.AnchorTop    = 0f;
             panel.AnchorBottom = 0f;
 
-            // OffsetLeft = PanelLeftOffset places the left edge PanelLeftOffset px from the screen's left.
-            // OffsetRight = PanelLeftOffset + PanelWidth places the right edge accordingly.
+            // Panel Offsets
             panel.OffsetLeft   = PanelLeftOffset;
             panel.OffsetRight  = PanelLeftOffset + PanelWidth;
             panel.OffsetTop    = PanelTopOffset;
@@ -375,9 +359,7 @@ namespace StS2AP.UI
             // Mouse passthrough — we don't need interaction on the tracker panel itself
             panel.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-            // ── Background style ──────────────────────────────────────────────────────
-            // Matches the look of the character info panel: semi-transparent, slightly
-            // rounded corners, no visible border.
+            // Background Panel
             var panelStyle = new StyleBoxFlat();
             panelStyle.BgColor = PanelBgColor;
             panelStyle.SetBorderWidthAll(0);
@@ -390,7 +372,7 @@ namespace StS2AP.UI
 
             root.AddChild(panel);
 
-            // ── Main content layout ────────────────────────────────────────────────────
+            // Main content layout
             var mainVbox = new VBoxContainer();
             mainVbox.Name = "MainContentVBox";
             mainVbox.AddThemeConstantOverride("separation", 8);
@@ -398,21 +380,16 @@ namespace StS2AP.UI
             mainVbox.SizeFlagsVertical   = Control.SizeFlags.Fill;
             panel.AddChild(mainVbox);
 
-            // ── Header label ───────────────────────────────────────────────────────────
-            // We use MegaRichTextLabel so BBCode and game text effects work out of the box,
-            // consistent with how ArchipelagoNotificationUI renders its messages.
+            // Header label
             _contentLabel = new MegaRichTextLabel();
             _contentLabel.Name = "CharTrackerHeaderLabel";
             _contentLabel.SizeFlagsHorizontal = Control.SizeFlags.ShrinkBegin;
-            // SizeFlagsVertical = 0 means don't expand; let FitContent size it to text height
             _contentLabel.SizeFlagsVertical   = 0;
             _contentLabel.FitContent          = true; // Fit to actual text height
             _contentLabel.AutowrapMode        = TextServer.AutowrapMode.Word;
             _contentLabel.BbcodeEnabled       = true; // Required for MegaRichTextLabel effects
             _contentLabel.MouseFilter         = Control.MouseFilterEnum.Ignore;
             _contentLabel.CustomMinimumSize   = new Vector2(PanelWidth - (PanelPadding * 2), 0);
-
-            // Placeholder text — this will be replaced by SetContent() if needed
             _contentLabel.Text = "[gold]Checks Found[/gold]                                 [gold]Received Items[/gold]";
 
             // Apply the game font so the text matches the rest of the UI
@@ -438,11 +415,7 @@ namespace StS2AP.UI
             /// after _Ready() has already fired, matching the pattern in ArchipelagoNotificationUI.
             mainVbox.AddChild(_contentLabel);
 
-            // ── Two-list layout (absolute positioning) ────────────────────────────────
-            // We use a plain Control as a full-width row and anchor each list at a fixed
-            // OffsetLeft so the right list's position is completely independent of how
-            // wide the left list grows. Each list is an HBoxContainer that spawns new
-            // VBoxContainer sub-columns automatically once MaxRowsPerColumn is reached.
+            // Two-list layout for checks + items
             var listsRow = new Control();
             listsRow.Name = "ListsRow";
             listsRow.SizeFlagsHorizontal = Control.SizeFlags.Fill;
@@ -450,7 +423,7 @@ namespace StS2AP.UI
             listsRow.MouseFilter         = Control.MouseFilterEnum.Ignore;
             mainVbox.AddChild(listsRow);
 
-            // LEFT list — AP Checks, anchored at the left edge of the panel interior
+            // List for AP Checks, anchored at the left edge of the panel interior
             _leftListContainer = new HBoxContainer();
             _leftListContainer.Name        = "LeftListContainer";
             _leftListContainer.AnchorLeft  = 0f;
@@ -462,7 +435,7 @@ namespace StS2AP.UI
             _leftListContainer.MouseFilter       = Control.MouseFilterEnum.Ignore;
             listsRow.AddChild(_leftListContainer);
 
-            // RIGHT list — AP Items, anchored at the panel midpoint regardless of left list width
+            // List for AP Items, anchored at the panel midpoint regardless of left list width
             _rightListContainer = new HBoxContainer();
             _rightListContainer.Name        = "RightListContainer";
             _rightListContainer.AnchorLeft  = 0f;
@@ -475,8 +448,6 @@ namespace StS2AP.UI
             listsRow.AddChild(_rightListContainer);
 
             // ── AP Checks ───────────────────────────────────────────────────────
-            // Each label is stored as a static property so patches can update its text
-            // at runtime via SetText(), e.g. CardChecks?.SetText("(15 / 45)").
 
             // Card Checks Counter
             CardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "(0 / 0)", tooltipTitle: "Card Checks", tooltipDescription: "The number of AP Checks found that replaced Card Rewards");

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -1,0 +1,506 @@
+﻿using Godot;
+using MegaCrit.Sts2.addons.mega_text;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using StS2AP.UI.Components;
+using StS2AP.Utils;
+using System;
+
+namespace StS2AP.UI
+{
+    /// <summary>
+    /// Static class that creates and manages the Archipelago Progress Tracker panel
+    /// on the Character Select screen.
+    ///
+    /// The panel is positioned on the left side of the screen, offset ~200 logical
+    /// pixels from the left edge and near the top of the viewport — intentionally
+    /// mirroring the vertical position and size of the game's own InfoPanel
+    /// (<see cref="NCharacterSelectScreen"/> node: "InfoPanel").
+    ///
+    /// Injected via <see cref="CharTrackerInjectionPatch"/> which postfixes
+    /// <see cref="NCharacterSelectScreen.OnSubmenuOpened"/> and
+    /// <see cref="NCharacterSelectScreen.OnSubmenuClosed"/>.
+    /// </summary>
+    public static class ArchipelagoCharTrackerUI
+    {
+        #region Node References
+
+        /// <summary>The root Control node added to the CanvasLayer.</summary>
+        private static Control? _rootPanel;
+
+        /// <summary>The CanvasLayer that hosts our panel so it renders on top of the scene.</summary>
+        private static CanvasLayer? _canvasLayer;
+
+        /// <summary>
+        /// The rich-text label inside the panel where progress content will be written.
+        /// Uses <see cref="MegaRichTextLabel"/> (same as <see cref="ArchipelagoNotificationUI"/>)
+        /// to support BBCode and the game's custom text effects.
+        /// </summary>
+        private static MegaRichTextLabel? _contentLabel;
+
+        /// <summary>
+        /// The HBoxContainer holding the left list's sub-columns (AP Checks).
+        /// Columns are added automatically when the row count reaches <see cref="MaxRowsPerColumn"/>.
+        /// </summary>
+        private static HBoxContainer? _leftListContainer;
+
+        /// <summary>
+        /// The HBoxContainer holding the right list's sub-columns (AP Items).
+        /// Columns are added automatically when the row count reaches <see cref="MaxRowsPerColumn"/>.
+        /// </summary>
+        private static HBoxContainer? _rightListContainer;
+
+        // Tracks the active VBoxContainer column and current row count for each list
+        private static VBoxContainer? _leftCurrentColumn;
+        private static int            _leftColumnRowCount;
+        private static VBoxContainer? _rightCurrentColumn;
+        private static int            _rightColumnRowCount;
+
+        #endregion
+
+        #region Constants
+
+        // The game font used throughout the mod for consistency
+        private const string FontPath = "res://fonts/kreon_regular.ttf";
+
+        // Font size matching the character info panel's body text
+        private const int FontSize = 24;
+
+        // Padding inside the panel (matches the feel of the InfoPanel)
+        private const float PanelPadding = 20f;
+
+        // Panel offsets — chosen to align with the game's InfoPanel vertical position.
+        private const float PanelLeftOffset = 220f;
+        private const float PanelTopOffset  = 16f;
+
+        // Panel Size
+        private const float PanelWidth  = 680f;
+        private const float PanelHeight = 300f;
+
+        // Semi-transparent dark background
+        private static readonly Color PanelBgColor = new Color(0.10f, 0.10f, 0.13f, 0.5f);
+
+        // CanvasLayer rendering order
+        private const int CanvasLayerIndex = 99;
+
+        // Maximum rows per sub-column before wrapping to a new column
+        private const int MaxRowsPerColumn = 6;
+
+        // Fixed left-edge offsets (relative to the panel's usable interior) for each list.
+        // Using absolute offsets keeps the right list position independent of the left list width.
+        private const float ChecksListLeft = 0f;
+        private const float ItemsListLeft  = (PanelWidth - (PanelPadding * 2)) / 2f;
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether the tracker panel is currently present and visible.
+        /// </summary>
+        public static bool IsVisible => _rootPanel?.Visible ?? false;
+
+        /// <summary>
+        /// Injects the tracker panel into the scene tree, creating it if it does not yet exist.
+        /// Safe to call multiple times — duplicate injection is ignored.
+        /// </summary>
+        public static void InjectUI()
+        {
+            try
+            {
+                var sceneTree = Engine.GetMainLoop() as SceneTree;
+                if (sceneTree == null)
+                {
+                    LogUtility.Error("[CharTracker] Failed to get SceneTree — cannot inject tracker UI");
+                    return;
+                }
+
+                var root = sceneTree.Root;
+                if (root == null)
+                {
+                    LogUtility.Error("[CharTracker] Failed to get root node — cannot inject tracker UI");
+                    return;
+                }
+
+                // Avoid rebuilding the UI if it is already present
+                if (_rootPanel != null && IsInstanceValid(_rootPanel))
+                {
+                    Show();
+                    return;
+                }
+
+                // Build and attach
+                _rootPanel = CreateUI();
+
+                _canvasLayer = new CanvasLayer();
+                _canvasLayer.Name = "ArchipelagoCharTrackerLayer";
+                _canvasLayer.Layer = CanvasLayerIndex;
+                _canvasLayer.AddChild(_rootPanel);
+                root.AddChild(_canvasLayer);
+
+                // SetContent() must be called after the node is in the tree — MegaRichTextLabel._Ready()
+                // resets font size overrides on tree entry, so we apply ours immediately after.
+                SetContent("[gold]Checks Found[/gold]                                 [gold]Received Items[/gold]");
+
+                LogUtility.Success("[CharTracker] Archipelago char-tracker UI injected successfully");
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Error($"[CharTracker] Failed to inject tracker UI: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Removes the tracker panel from the scene tree entirely and resets all node references.
+        /// Called when the Character Select screen is closed.
+        /// </summary>
+        public static void RemoveUI()
+        {
+            if (_canvasLayer != null && IsInstanceValid(_canvasLayer))
+            {
+                _canvasLayer.QueueFree();
+                _canvasLayer         = null;
+                _rootPanel           = null;
+                _contentLabel        = null;
+                _leftListContainer   = null;
+                _rightListContainer  = null;
+                _leftCurrentColumn   = null;
+                _leftColumnRowCount  = 0;
+                _rightCurrentColumn  = null;
+                _rightColumnRowCount = 0;
+            }
+        }
+
+        /// <summary>
+        /// Makes the tracker panel visible.
+        /// </summary>
+        public static void Show()
+        {
+            if (_rootPanel != null && IsInstanceValid(_rootPanel))
+            {
+                _rootPanel.Visible = true;
+            }
+        }
+
+        /// <summary>
+        /// Hides the tracker panel without removing it from the tree.
+        /// </summary>
+        public static void Hide()
+        {
+            if (_rootPanel != null && IsInstanceValid(_rootPanel))
+            {
+                _rootPanel.Visible = false;
+            }
+        }
+
+        /// <summary>
+        /// Replaces the content displayed inside the tracker panel.
+        /// Supports full BBCode (including the game's custom [sine], [rainbow], etc. effects).
+        /// </summary>
+        /// <param name="bbcodeText">BBCode-formatted string to display.</param>
+        public static void SetContent(string bbcodeText)
+        {
+            if (_contentLabel != null && IsInstanceValid(_contentLabel))
+            {
+                // Re-apply the font size each time — the game sometimes resets theme overrides
+                _contentLabel.RemoveThemeFontSizeOverride("normal_font_size");
+                _contentLabel.AddThemeFontSizeOverride("normal_font_size", FontSize);
+
+                _contentLabel.Text = bbcodeText;
+            }
+        }
+
+        /// <summary>
+        /// Adds an <see cref="ItemCountLabel"/> row to the LEFT (Checks) list.
+        /// Automatically wraps into a new sub-column after every <see cref="MaxRowsPerColumn"/> rows.
+        /// </summary>
+        /// <param name="row">The ItemCountLabel to add.</param>
+        public static void AddCheckRow(ItemCountLabel row)
+        {
+            if (_leftListContainer == null || !IsInstanceValid(_leftListContainer))
+            {
+                LogUtility.Warn("[CharTracker] Left list container not yet initialized; row will not be added");
+                return;
+            }
+            AddRowToList(row, _leftListContainer, ref _leftCurrentColumn, ref _leftColumnRowCount);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="ItemCountLabel"/> row to the RIGHT (Items) list.
+        /// Automatically wraps into a new sub-column after every <see cref="MaxRowsPerColumn"/> rows.
+        /// The right list's position is fixed and independent of the left list's width.
+        /// </summary>
+        /// <param name="row">The ItemCountLabel to add.</param>
+        public static void AddItemRow(ItemCountLabel row)
+        {
+            if (_rightListContainer == null || !IsInstanceValid(_rightListContainer))
+            {
+                LogUtility.Warn("[CharTracker] Right list container not yet initialized; row will not be added");
+                return;
+            }
+            AddRowToList(row, _rightListContainer, ref _rightCurrentColumn, ref _rightColumnRowCount);
+        }
+
+        #endregion
+
+        #region UI Construction
+
+        /// <summary>
+        /// Builds the entire panel hierarchy from scratch (no Godot editor scenes available).
+        ///
+        /// Layout (left-anchored):
+        /// <code>
+        ///   Control (root, FullRect)
+        ///     └─ PanelContainer  ← semi-transparent background, fixed size, top-left anchor
+        ///          └─ VBoxContainer (main content vbox)
+        ///               ├─ MegaRichTextLabel  ← header/title
+        ///               └─ Control (listsRow, full-width, absolute children)
+        ///                    ├─ HBoxContainer (_leftListContainer,  OffsetLeft=ChecksListLeft)
+        ///                    │    └─ VBoxContainer columns (max MaxRowsPerColumn rows each)
+        ///                    └─ HBoxContainer (_rightListContainer, OffsetLeft=ItemsListLeft)
+        ///                         └─ VBoxContainer columns (max MaxRowsPerColumn rows each)
+        /// </code>
+        /// </summary>
+        private static Control CreateUI()
+        {
+            // ── Root ──────────────────────────────────────────────────────────────────
+            // Full-rect so anchors/offsets work relative to the full viewport.
+            var root = new Control();
+            root.Name = "ArchipelagoCharTrackerUI";
+            root.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+            // Pass all mouse events through so we don't block game input
+            root.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // ── Panel ─────────────────────────────────────────────────────────────────
+            // Anchored to the top-left corner to sit alongside the game's InfoPanel.
+            // PanelLeftOffset pushes us ~200 px from the left edge so the panel doesn't
+            // overlap the character buttons, mirroring the InfoPanel's horizontal position.
+            var panel = new PanelContainer();
+            panel.Name = "CharTrackerPanel";
+            panel.CustomMinimumSize = new Vector2(PanelWidth, PanelHeight);
+
+            // Position: anchor top-left, then shift right by PanelLeftOffset.
+            panel.AnchorLeft   = 0f;
+            panel.AnchorRight  = 0f;
+            panel.AnchorTop    = 0f;
+            panel.AnchorBottom = 0f;
+
+            // OffsetLeft = PanelLeftOffset places the left edge PanelLeftOffset px from the screen's left.
+            // OffsetRight = PanelLeftOffset + PanelWidth places the right edge accordingly.
+            panel.OffsetLeft   = PanelLeftOffset;
+            panel.OffsetRight  = PanelLeftOffset + PanelWidth;
+            panel.OffsetTop    = PanelTopOffset;
+            panel.OffsetBottom = PanelTopOffset + PanelHeight;
+
+            // Mouse passthrough — we don't need interaction on the tracker panel itself
+            panel.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // ── Background style ──────────────────────────────────────────────────────
+            // Matches the look of the character info panel: semi-transparent, slightly
+            // rounded corners, no visible border.
+            var panelStyle = new StyleBoxFlat();
+            panelStyle.BgColor = PanelBgColor;
+            panelStyle.SetBorderWidthAll(0);
+            panelStyle.SetCornerRadiusAll(10);
+            panelStyle.ContentMarginLeft   = PanelPadding;
+            panelStyle.ContentMarginRight  = PanelPadding;
+            panelStyle.ContentMarginTop    = PanelPadding;
+            panelStyle.ContentMarginBottom = PanelPadding;
+            panel.AddThemeStyleboxOverride("panel", panelStyle);
+
+            root.AddChild(panel);
+
+            // ── Main content layout ────────────────────────────────────────────────────
+            var mainVbox = new VBoxContainer();
+            mainVbox.Name = "MainContentVBox";
+            mainVbox.AddThemeConstantOverride("separation", 8);
+            mainVbox.SizeFlagsHorizontal = Control.SizeFlags.Fill;
+            mainVbox.SizeFlagsVertical   = Control.SizeFlags.Fill;
+            panel.AddChild(mainVbox);
+
+            // ── Header label ───────────────────────────────────────────────────────────
+            // We use MegaRichTextLabel so BBCode and game text effects work out of the box,
+            // consistent with how ArchipelagoNotificationUI renders its messages.
+            _contentLabel = new MegaRichTextLabel();
+            _contentLabel.Name = "CharTrackerHeaderLabel";
+            _contentLabel.SizeFlagsHorizontal = Control.SizeFlags.ShrinkBegin;
+            // SizeFlagsVertical = 0 means don't expand; let FitContent size it to text height
+            _contentLabel.SizeFlagsVertical   = 0;
+            _contentLabel.FitContent          = true; // Fit to actual text height
+            _contentLabel.AutowrapMode        = TextServer.AutowrapMode.Word;
+            _contentLabel.BbcodeEnabled       = true; // Required for MegaRichTextLabel effects
+            _contentLabel.MouseFilter         = Control.MouseFilterEnum.Ignore;
+            _contentLabel.CustomMinimumSize   = new Vector2(PanelWidth - (PanelPadding * 2), 0);
+
+            // Placeholder text — this will be replaced by SetContent() if needed
+            _contentLabel.Text = "[gold]Checks Found[/gold]                                 [gold]Received Items[/gold]";
+
+            // Apply the game font so the text matches the rest of the UI
+            try
+            {
+                var font = GD.Load<Font>(FontPath);
+                if (font != null)
+                {
+                    _contentLabel.AddThemeFontOverride("normal_font", font);
+                }
+                else
+                {
+                    LogUtility.Warn($"[CharTracker] Could not load font: {FontPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn($"[CharTracker] Failed to load header label font: {ex.Message}");
+            }
+
+            /// Font size is intentionally NOT set here — MegaRichTextLabel._Ready() fires when the
+            /// node enters the tree and resets font size overrides. SetContent() applies it at runtime
+            /// after _Ready() has already fired, matching the pattern in ArchipelagoNotificationUI.
+            mainVbox.AddChild(_contentLabel);
+
+            // ── Two-list layout (absolute positioning) ────────────────────────────────
+            // We use a plain Control as a full-width row and anchor each list at a fixed
+            // OffsetLeft so the right list's position is completely independent of how
+            // wide the left list grows. Each list is an HBoxContainer that spawns new
+            // VBoxContainer sub-columns automatically once MaxRowsPerColumn is reached.
+            var listsRow = new Control();
+            listsRow.Name = "ListsRow";
+            listsRow.SizeFlagsHorizontal = Control.SizeFlags.Fill;
+            listsRow.SizeFlagsVertical   = Control.SizeFlags.Fill;
+            listsRow.MouseFilter         = Control.MouseFilterEnum.Ignore;
+            mainVbox.AddChild(listsRow);
+
+            // LEFT list — AP Checks, anchored at the left edge of the panel interior
+            _leftListContainer = new HBoxContainer();
+            _leftListContainer.Name        = "LeftListContainer";
+            _leftListContainer.AnchorLeft  = 0f;
+            _leftListContainer.AnchorRight = 0f;
+            _leftListContainer.AnchorTop   = 0f;
+            _leftListContainer.OffsetLeft  = ChecksListLeft;
+            _leftListContainer.AddThemeConstantOverride("separation", 4);
+            _leftListContainer.SizeFlagsVertical = Control.SizeFlags.Fill;
+            _leftListContainer.MouseFilter       = Control.MouseFilterEnum.Ignore;
+            listsRow.AddChild(_leftListContainer);
+
+            // RIGHT list — AP Items, anchored at the panel midpoint regardless of left list width
+            _rightListContainer = new HBoxContainer();
+            _rightListContainer.Name        = "RightListContainer";
+            _rightListContainer.AnchorLeft  = 0f;
+            _rightListContainer.AnchorRight = 0f;
+            _rightListContainer.AnchorTop   = 0f;
+            _rightListContainer.OffsetLeft  = ItemsListLeft;
+            _rightListContainer.AddThemeConstantOverride("separation", 4);
+            _rightListContainer.SizeFlagsVertical = Control.SizeFlags.Fill;
+            _rightListContainer.MouseFilter       = Control.MouseFilterEnum.Ignore;
+            listsRow.AddChild(_rightListContainer);
+
+            // ── AP Checks ───────────────────────────────────────────────────────
+
+            // Press Start Counter
+            var pressStartChecks = new ItemCountLabel("res://images/ui/run_history/neow.png", "✔");
+            AddCheckRow(pressStartChecks);
+
+            // Slayed the Spire Counter
+            var clearedChecks = new ItemCountLabel("res://images/ui/emote/skull.png", "✔");
+            AddCheckRow(clearedChecks);
+
+            // Card Checks Counter
+            var cardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "(12 / 45)");
+            AddCheckRow(cardChecks);
+
+            // Rare Card Checks Counter
+            var rareCardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "(2 / 2)");
+            AddCheckRow(rareCardChecks);
+
+            // Floorsanity Checks Counter (Note: When the Winged Boots are in main, we should use that relic here instead)
+            var floorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(18 / 45)");
+            AddCheckRow(floorsanityChecks);
+
+            // Potionsanity Checks Counter
+            var potionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(5 / 10)");
+            AddCheckRow(potionsanityChecks);
+
+            // Goldsanity Checks Counter
+            var goldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(28 / 45)");
+            AddCheckRow(goldsanityChecks);
+
+            // Campfiresanity Checks Counter
+            var campfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(3 / 5)");
+            AddCheckRow(campfiresanityChecks);
+
+            // ── AP Items ──────────────────────────────────────────────────────
+
+            // Card Rewards Counter
+            var cardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "25");
+            AddItemRow(cardRewards);
+
+            // Rare Card Rewards Counter
+            var rareCardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "3");
+            AddItemRow(rareCardRewards);
+
+            // Relics Counter
+            var relicRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_shared_relic.png", "7");
+            AddItemRow(relicRewards);
+
+            // Potions Counter
+            var potionRewards = new ItemCountLabel("res://images/potions/glowwater_potion.png", "12");
+            AddItemRow(potionRewards);
+
+            // Gold Rewards Total
+            var goldRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "9200");
+            AddItemRow(goldRewards);
+
+            // Progressive Rest Total
+            var progressiveRest = new ItemCountLabel("res://images/relics/regal_pillow.png", "(0 / 3)");
+            AddItemRow(progressiveRest);
+
+            // Progressive Smith Total
+            var progressiveSmith = new ItemCountLabel("res://images/relics/whetstone.png", "(2 / 3)");
+            AddItemRow(progressiveSmith);
+
+            // Start visible — it will be shown/hidden by the patch hooks
+            root.Visible = true;
+
+            return root;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Checks whether a GodotObject instance is still valid (not null and not freed).
+        /// </summary>
+        private static bool IsInstanceValid(GodotObject obj)
+        {
+            return GodotObject.IsInstanceValid(obj);
+        }
+
+        /// <summary>
+        /// Adds <paramref name="row"/> to <paramref name="listContainer"/>, automatically
+        /// creating a new <see cref="VBoxContainer"/> sub-column whenever
+        /// <see cref="MaxRowsPerColumn"/> rows have been placed in the current one.
+        /// </summary>
+        private static void AddRowToList(
+            ItemCountLabel   row,
+            HBoxContainer    listContainer,
+            ref VBoxContainer? currentColumn,
+            ref int            columnRowCount)
+        {
+            // Spin up a new column if we haven't started one yet, or the current one is full
+            if (currentColumn == null || !IsInstanceValid(currentColumn) || columnRowCount >= MaxRowsPerColumn)
+            {
+                currentColumn = new VBoxContainer();
+                currentColumn.AddThemeConstantOverride("separation", 4);
+                currentColumn.SizeFlagsVertical = Control.SizeFlags.Fill;
+                currentColumn.MouseFilter       = Control.MouseFilterEnum.Ignore;
+                listContainer.AddChild(currentColumn);
+                columnRowCount = 0;
+            }
+
+            currentColumn.AddChild(row.Root);
+            columnRowCount++;
+        }
+
+        #endregion
+    }
+}

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -1,5 +1,6 @@
 ﻿using Godot;
 using MegaCrit.Sts2.addons.mega_text;
+using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using StS2AP.Data;
 using StS2AP.Models;
@@ -164,7 +165,7 @@ namespace StS2AP.UI
         /// Injects the tracker panel into the scene tree, creating it if it does not yet exist.
         /// Safe to call multiple times — duplicate injection is ignored.
         /// </summary>
-        public static void InjectUI()
+        public static void InjectUI(CharacterModel character)
         {
             try
             {
@@ -190,7 +191,7 @@ namespace StS2AP.UI
                 }
 
                 // Build and attach
-                _rootPanel = CreateUI();
+                _rootPanel = CreateUI(character);
 
                 _canvasLayer = new CanvasLayer();
                 _canvasLayer.Name = "ArchipelagoCharTrackerLayer";
@@ -339,7 +340,8 @@ namespace StS2AP.UI
         ///                         └─ VBoxContainer columns (max MaxRowsPerColumn rows each)
         /// </code>
         /// </summary>
-        private static Control CreateUI()
+        /// <param name="character">The initial character to display information for</param>
+        private static Control CreateUI(CharacterModel character)
         {
             // ── Root ──────────────────────────────────────────────────────────────────
             // Full-rect so anchors/offsets work relative to the full viewport.
@@ -553,6 +555,10 @@ namespace StS2AP.UI
             // Progressive Smith Total
             ProgressiveSmithLabel = new ItemCountLabel("res://images/relics/whetstone.png", "(0 / 3)", tooltipTitle: "Progressive Smiths", tooltipDescription: "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at.");
             AddItemRow(ProgressiveSmithLabel);
+
+            // Set initial values based on the first character from the select screen
+            UpdateCharTrackerUI.UpdateCheckedLocations(character);
+            UpdateCharTrackerUI.UpdateReceivedItems(character);
 
             return root;
         }

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -57,6 +57,64 @@ namespace StS2AP.UI
 
         #endregion
 
+        #region ItemCountLabel References
+
+        // ── AP Check labels (left list) ───────────────────────────────────────────
+        // Each label can be updated at runtime via its SetText() method, e.g.:
+        //   ArchipelagoCharTrackerUI.CardChecks?.SetText("(15 / 45)");
+
+        /// <summary>Tracks how many Card Reward AP Checks have been found.</summary>
+        public static ItemCountLabel? CardChecks { get; private set; }
+
+        /// <summary>Tracks how many Rare Card Reward AP Checks have been found.</summary>
+        public static ItemCountLabel? RareCardChecks { get; private set; }
+
+        /// <summary>Tracks how many Relic Reward AP Checks have been found.</summary>
+        public static ItemCountLabel? RelicChecks { get; private set; }
+
+        /// <summary>Tracks how many Floorsanity AP Checks have been sent.</summary>
+        public static ItemCountLabel? FloorsanityChecks { get; private set; }
+
+        /// <summary>Tracks how many Potionsanity AP Checks have been found.</summary>
+        public static ItemCountLabel? PotionsanityChecks { get; private set; }
+
+        /// <summary>Tracks how many Goldsanity AP Checks have been found.</summary>
+        public static ItemCountLabel? GoldsanityChecks { get; private set; }
+
+        /// <summary>Tracks how many Campfiresanity AP Checks have been found.</summary>
+        public static ItemCountLabel? CampfiresanityChecks { get; private set; }
+
+        /// <summary>Tracks whether the "Press Start" check has been earned.</summary>
+        public static ItemCountLabel? PressStartChecks { get; private set; }
+
+        /// <summary>Tracks whether the "Slayed the Spire" check has been earned.</summary>
+        public static ItemCountLabel? ClearedChecks { get; private set; }
+
+        // ── AP Item labels (right list) ───────────────────────────────────────────
+
+        /// <summary>Tracks the number of Card Rewards received from the multiworld.</summary>
+        public static ItemCountLabel? CardRewards { get; private set; }
+
+        /// <summary>Tracks the number of Rare Card Rewards received from the multiworld.</summary>
+        public static ItemCountLabel? RareCardRewards { get; private set; }
+
+        /// <summary>Tracks the number of Relic Rewards received from the multiworld.</summary>
+        public static ItemCountLabel? RelicRewards { get; private set; }
+
+        /// <summary>Tracks the number of Potion Rewards received from the multiworld.</summary>
+        public static ItemCountLabel? PotionRewards { get; private set; }
+
+        /// <summary>Tracks the total Gold received from the multiworld.</summary>
+        public static ItemCountLabel? GoldRewards { get; private set; }
+
+        /// <summary>Tracks the number of Progressive Rest rewards received.</summary>
+        public static ItemCountLabel? ProgressiveRestLabel { get; private set; }
+
+        /// <summary>Tracks the number of Progressive Smith rewards received.</summary>
+        public static ItemCountLabel? ProgressiveSmithLabel { get; private set; }
+
+        #endregion
+
         #region Constants
 
         // The game font used throughout the mod for consistency
@@ -169,6 +227,24 @@ namespace StS2AP.UI
                 _leftColumnRowCount  = 0;
                 _rightCurrentColumn  = null;
                 _rightColumnRowCount = 0;
+
+                // Reset all ItemCountLabel references — their Godot nodes are freed with the canvas layer
+                CardChecks           = null;
+                RareCardChecks       = null;
+                RelicChecks          = null;
+                FloorsanityChecks    = null;
+                PotionsanityChecks   = null;
+                GoldsanityChecks     = null;
+                CampfiresanityChecks = null;
+                PressStartChecks     = null;
+                ClearedChecks        = null;
+                CardRewards          = null;
+                RareCardRewards      = null;
+                RelicRewards         = null;
+                PotionRewards        = null;
+                GoldRewards          = null;
+                ProgressiveRestLabel = null;
+                ProgressiveSmithLabel = null;
             }
         }
 
@@ -396,72 +472,74 @@ namespace StS2AP.UI
             listsRow.AddChild(_rightListContainer);
 
             // ── AP Checks ───────────────────────────────────────────────────────
+            // Each label is stored as a static property so patches can update its text
+            // at runtime via SetText(), e.g. CardChecks?.SetText("(15 / 45)").
 
             // Card Checks Counter
-            var cardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "(12 / 45)", tooltipTitle: "Card Checks", tooltipDescription: "The number of AP Checks found that replaced Card Rewards");
-            AddCheckRow(cardChecks);
+            CardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "(0 / 0)", tooltipTitle: "Card Checks", tooltipDescription: "The number of AP Checks found that replaced Card Rewards");
+            AddCheckRow(CardChecks);
 
             // Rare Card Checks Counter
-            var rareCardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "(2 / 2)", tooltipTitle: "Rare Card Checks", tooltipDescription: "The number of AP Checks found that replaced Rare Card Rewards");
-            AddCheckRow(rareCardChecks);
+            RareCardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "(0 / 0)", tooltipTitle: "Rare Card Checks", tooltipDescription: "The number of AP Checks found that replaced Rare Card Rewards");
+            AddCheckRow(RareCardChecks);
 
             // Relic Checks Counter
-            var relicChecks = new ItemCountLabel("res://images/relics/calling_bell.png", "(4 / 10)", tooltipTitle: "Relic Checks", tooltipDescription: "The number of AP Checks found that replaced Relic Rewards");
-            AddCheckRow(relicChecks);
+            RelicChecks = new ItemCountLabel("res://images/relics/calling_bell.png", "(0 / 0)", tooltipTitle: "Relic Checks", tooltipDescription: "The number of AP Checks found that replaced Relic Rewards");
+            AddCheckRow(RelicChecks);
 
             // Floorsanity Checks Counter (Note: When the Winged Boots are in main, we should use that relic here instead)
-            var floorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(18 / 45)", tooltipTitle: "Floorsanity Checks", tooltipDescription: "The number of AP Checks sent for each floor reached");
-            AddCheckRow(floorsanityChecks);
+            FloorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(0 / 0)", tooltipTitle: "Floorsanity Checks", tooltipDescription: "The number of AP Checks sent for each floor reached");
+            AddCheckRow(FloorsanityChecks);
 
             // Potionsanity Checks Counter
-            var potionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(5 / 10)", tooltipTitle: "Potionsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Potion Rewards");
-            AddCheckRow(potionsanityChecks);
+            PotionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(0 / 0)", tooltipTitle: "Potionsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Potion Rewards");
+            AddCheckRow(PotionsanityChecks);
 
             // Goldsanity Checks Counter
-            var goldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(28 / 45)", tooltipTitle: "Goldsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Gold Rewards");
-            AddCheckRow(goldsanityChecks);
+            GoldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(0 / 0)", tooltipTitle: "Goldsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Gold Rewards");
+            AddCheckRow(GoldsanityChecks);
 
             // Campfiresanity Checks Counter
-            var campfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(3 / 6)", tooltipTitle: "Campfiresanity Checks", tooltipDescription: "The number of AP Checks found from Rest Sites");
-            AddCheckRow(campfiresanityChecks);
+            CampfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(0 / 0)", tooltipTitle: "Campfiresanity Checks", tooltipDescription: "The number of AP Checks found from Rest Sites");
+            AddCheckRow(CampfiresanityChecks);
 
             // Press Start Counter
-            var pressStartChecks = new ItemCountLabel("res://images/ui/run_history/neow.png", "✔", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
-            AddCheckRow(pressStartChecks);
+            PressStartChecks = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
+            AddCheckRow(PressStartChecks);
 
             // Slayed the Spire Counter
-            var clearedChecks = new ItemCountLabel("res://images/relics/pantograph.png", "✔", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");
-            AddCheckRow(clearedChecks);
+            ClearedChecks = new ItemCountLabel("res://images/relics/pantograph.png", "—", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");
+            AddCheckRow(ClearedChecks);
 
             // ── AP Items ──────────────────────────────────────────────────────
 
             // Card Rewards Counter
-            var cardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "25", tooltipTitle: "Card Rewards", tooltipDescription: "The number of Card Rewards received for this character. You can redeem these at the start of each run.");
-            AddItemRow(cardRewards);
+            CardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "0", tooltipTitle: "Card Rewards", tooltipDescription: "The number of Card Rewards received for this character. You can redeem these at the start of each run.");
+            AddItemRow(CardRewards);
 
             // Rare Card Rewards Counter
-            var rareCardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "3", tooltipTitle: "Rare Card Rewards", tooltipDescription: "The number of Rare Card Rewards received for this character. You can redeem these at the start of each run.");
-            AddItemRow(rareCardRewards);
+            RareCardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "0", tooltipTitle: "Rare Card Rewards", tooltipDescription: "The number of Rare Card Rewards received for this character. You can redeem these at the start of each run.");
+            AddItemRow(RareCardRewards);
 
             // Relics Counter
-            var relicRewards = new ItemCountLabel("res://images/relics/circlet.png", "7", tooltipTitle: "Relic Rewards", tooltipDescription: "The number of Relic Rewards received for this character. You can redeem these at the start of each run.");
-            AddItemRow(relicRewards);
+            RelicRewards = new ItemCountLabel("res://images/relics/circlet.png", "0", tooltipTitle: "Relic Rewards", tooltipDescription: "The number of Relic Rewards received for this character. You can redeem these at the start of each run.");
+            AddItemRow(RelicRewards);
 
             // Potions Counter
-            var potionRewards = new ItemCountLabel("res://images/potions/glowwater_potion.png", "12", tooltipTitle: "Potion Rewards", tooltipDescription: "The number of Potion Rewards received for this character. You can redeem these at the start of each run.");
-            AddItemRow(potionRewards);
+            PotionRewards = new ItemCountLabel("res://images/potions/glowwater_potion.png", "0", tooltipTitle: "Potion Rewards", tooltipDescription: "The number of Potion Rewards received for this character. You can redeem these at the start of each run.");
+            AddItemRow(PotionRewards);
 
             // Gold Rewards Total
-            var goldRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "", tooltipTitle: "Gold", tooltipDescription: "The total amount of Gold received for this character. You can redeem this at the start of each run.");
-            AddItemRow(goldRewards);
+            GoldRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "0", tooltipTitle: "Gold", tooltipDescription: "The total amount of Gold received for this character. You can redeem this at the start of each run.");
+            AddItemRow(GoldRewards);
 
             // Progressive Rest Total
-            var progressiveRest = new ItemCountLabel("res://images/relics/regal_pillow.png", "(0 / 3)", tooltipTitle: "Progressive Rests", tooltipDescription: "The number of Progressive Rest rewards received for this character. The number of these represents the highest Act you can Heal at.");
-            AddItemRow(progressiveRest);
+            ProgressiveRestLabel = new ItemCountLabel("res://images/relics/regal_pillow.png", "(0 / 3)", tooltipTitle: "Progressive Rests", tooltipDescription: "The number of Progressive Rest rewards received for this character. The number of these represents the highest Act you can Heal at.");
+            AddItemRow(ProgressiveRestLabel);
 
             // Progressive Smith Total
-            var progressiveSmith = new ItemCountLabel("res://images/relics/whetstone.png", "(2 / 3)", tooltipTitle: "Progressive Smiths", tooltipDescription: "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at.");
-            AddItemRow(progressiveSmith);
+            ProgressiveSmithLabel = new ItemCountLabel("res://images/relics/whetstone.png", "(0 / 3)", tooltipTitle: "Progressive Smiths", tooltipDescription: "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at.");
+            AddItemRow(ProgressiveSmithLabel);
 
             // Start visible — it will be shown/hidden by the patch hooks
             root.Visible = true;

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -515,8 +515,11 @@ namespace StS2AP.UI
             }
 
             // Press Start Counter
-            PressStartCheck = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
-            AddCheckRow(PressStartCheck);
+            if(!ArchipelagoClient.Settings.NoCharactersLocked)
+            {
+                PressStartCheck = new ItemCountLabel("res://images/ui/run_history/neow.png", "—", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
+                AddCheckRow(PressStartCheck);
+            }
 
             // Slayed the Spire Counter
             ClearedCheck = new ItemCountLabel("res://images/relics/pantograph.png", "—", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -79,8 +79,10 @@ namespace StS2AP.UI
         // Semi-transparent dark background
         private static readonly Color PanelBgColor = new Color(0.10f, 0.10f, 0.13f, 0.5f);
 
-        // CanvasLayer rendering order
-        private const int CanvasLayerIndex = 99;
+        // CanvasLayer rendering order.
+        // Kept low (below 100) so the game's own UI layers — connection UI (100), notification UI (101),
+        // reward UI (110), and the tooltip system — all render on top of this panel.
+        private const int CanvasLayerIndex = 10;
 
         // Maximum rows per sub-column before wrapping to a new column
         private const int MaxRowsPerColumn = 6;
@@ -395,66 +397,70 @@ namespace StS2AP.UI
 
             // ── AP Checks ───────────────────────────────────────────────────────
 
-            // Press Start Counter
-            var pressStartChecks = new ItemCountLabel("res://images/ui/run_history/neow.png", "✔");
-            AddCheckRow(pressStartChecks);
-
-            // Slayed the Spire Counter
-            var clearedChecks = new ItemCountLabel("res://images/ui/emote/skull.png", "✔");
-            AddCheckRow(clearedChecks);
-
             // Card Checks Counter
-            var cardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "(12 / 45)");
+            var cardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "(12 / 45)", tooltipTitle: "Card Checks", tooltipDescription: "The number of AP Checks found that replaced Card Rewards");
             AddCheckRow(cardChecks);
 
             // Rare Card Checks Counter
-            var rareCardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "(2 / 2)");
+            var rareCardChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "(2 / 2)", tooltipTitle: "Rare Card Checks", tooltipDescription: "The number of AP Checks found that replaced Rare Card Rewards");
             AddCheckRow(rareCardChecks);
 
+            // Relic Checks Counter
+            var relicChecks = new ItemCountLabel("res://images/relics/calling_bell.png", "(4 / 10)", tooltipTitle: "Relic Checks", tooltipDescription: "The number of AP Checks found that replaced Relic Rewards");
+            AddCheckRow(relicChecks);
+
             // Floorsanity Checks Counter (Note: When the Winged Boots are in main, we should use that relic here instead)
-            var floorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(18 / 45)");
+            var floorsanityChecks = new ItemCountLabel("res://images/relics/planisphere.png", "(18 / 45)", tooltipTitle: "Floorsanity Checks", tooltipDescription: "The number of AP Checks sent for each floor reached");
             AddCheckRow(floorsanityChecks);
 
             // Potionsanity Checks Counter
-            var potionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(5 / 10)");
+            var potionsanityChecks = new ItemCountLabel("res://images/potions/skill_potion.png", "(5 / 10)", tooltipTitle: "Potionsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Potion Rewards");
             AddCheckRow(potionsanityChecks);
 
             // Goldsanity Checks Counter
-            var goldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(28 / 45)");
+            var goldsanityChecks = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "(28 / 45)", tooltipTitle: "Goldsanity Checks", tooltipDescription: "The number of AP Checks found that replaced Gold Rewards");
             AddCheckRow(goldsanityChecks);
 
             // Campfiresanity Checks Counter
-            var campfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(3 / 5)");
+            var campfiresanityChecks = new ItemCountLabel("res://images/ui/run_history/rest_site.png", "(3 / 6)", tooltipTitle: "Campfiresanity Checks", tooltipDescription: "The number of AP Checks found from Rest Sites");
             AddCheckRow(campfiresanityChecks);
+
+            // Press Start Counter
+            var pressStartChecks = new ItemCountLabel("res://images/ui/run_history/neow.png", "✔", tooltipTitle: "Pressed Start", tooltipDescription: "Whether this character has earned a check by starting a run.");
+            AddCheckRow(pressStartChecks);
+
+            // Slayed the Spire Counter
+            var clearedChecks = new ItemCountLabel("res://images/relics/pantograph.png", "✔", tooltipTitle: "Slayed the Spire", tooltipDescription: "Whether this character has earned a check by completing a run.");
+            AddCheckRow(clearedChecks);
 
             // ── AP Items ──────────────────────────────────────────────────────
 
             // Card Rewards Counter
-            var cardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "25");
+            var cardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_card.png", "25", tooltipTitle: "Card Rewards", tooltipDescription: "The number of Card Rewards received for this character. You can redeem these at the start of each run.");
             AddItemRow(cardRewards);
 
             // Rare Card Rewards Counter
-            var rareCardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "3");
+            var rareCardRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_rare.png", "3", tooltipTitle: "Rare Card Rewards", tooltipDescription: "The number of Rare Card Rewards received for this character. You can redeem these at the start of each run.");
             AddItemRow(rareCardRewards);
 
             // Relics Counter
-            var relicRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_shared_relic.png", "7");
+            var relicRewards = new ItemCountLabel("res://images/relics/circlet.png", "7", tooltipTitle: "Relic Rewards", tooltipDescription: "The number of Relic Rewards received for this character. You can redeem these at the start of each run.");
             AddItemRow(relicRewards);
 
             // Potions Counter
-            var potionRewards = new ItemCountLabel("res://images/potions/glowwater_potion.png", "12");
+            var potionRewards = new ItemCountLabel("res://images/potions/glowwater_potion.png", "12", tooltipTitle: "Potion Rewards", tooltipDescription: "The number of Potion Rewards received for this character. You can redeem these at the start of each run.");
             AddItemRow(potionRewards);
 
             // Gold Rewards Total
-            var goldRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "9200");
+            var goldRewards = new ItemCountLabel("res://images/ui/reward_screen/reward_icon_money.png", "", tooltipTitle: "Gold", tooltipDescription: "The total amount of Gold received for this character. You can redeem this at the start of each run.");
             AddItemRow(goldRewards);
 
             // Progressive Rest Total
-            var progressiveRest = new ItemCountLabel("res://images/relics/regal_pillow.png", "(0 / 3)");
+            var progressiveRest = new ItemCountLabel("res://images/relics/regal_pillow.png", "(0 / 3)", tooltipTitle: "Progressive Rests", tooltipDescription: "The number of Progressive Rest rewards received for this character. The number of these represents the highest Act you can Heal at.");
             AddItemRow(progressiveRest);
 
             // Progressive Smith Total
-            var progressiveSmith = new ItemCountLabel("res://images/relics/whetstone.png", "(2 / 3)");
+            var progressiveSmith = new ItemCountLabel("res://images/relics/whetstone.png", "(2 / 3)", tooltipTitle: "Progressive Smiths", tooltipDescription: "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at.");
             AddItemRow(progressiveSmith);
 
             // Start visible — it will be shown/hidden by the patch hooks

--- a/client/StS2AP/UI/ArchipelagoGoalTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoGoalTrackerUI.cs
@@ -39,18 +39,18 @@ namespace StS2AP.UI
         private const string FontPath = "res://fonts/kreon_regular.ttf";
 
         // Font size for the goal text
-        private const int FontSize = 32;
+        private const int FontSize = 24;
 
         // Padding inside the panel
         private const float PanelPadding = 16f;
 
         // Panel offsets — positioned in the bottom-left corner of the screen
         private const float PanelLeftOffset   = 220f;
-        private const float PanelBottomOffset = 250f;
+        private const float PanelBottomOffset = 268f;
 
         // Panel size — kept compact since it only holds a single label
         private const float PanelWidth  = 400f;
-        private const float PanelHeight = 80f;
+        private const float PanelHeight = 70f;
 
         // Semi-transparent dark background matching ArchipelagoCharTrackerUI
         private static readonly Color PanelBgColor = new Color(0.10f, 0.10f, 0.13f, 0.5f);
@@ -155,7 +155,7 @@ namespace StS2AP.UI
         /// Supports full BBCode (including the game's custom [sine], [rainbow], etc. effects).
         /// </summary>
         /// <param name="bbcodeText">BBCode-formatted string to display.</param>
-        public static void SetContent(string bbcodeText)
+        private static void SetContent(string bbcodeText)
         {
             if (_contentLabel != null && IsInstanceValid(_contentLabel))
             {
@@ -165,6 +165,11 @@ namespace StS2AP.UI
 
                 _contentLabel.Text = bbcodeText;
             }
+        }
+
+        public static void UpdateGoalProgress()
+        {
+            SetContent($"[gold]Goal: Slay the Spire with {ArchipelagoClient.Settings.NumCharsGoal} Characters[/gold]\nProgress: {GameUtility.GoaledCharactersCount} / {ArchipelagoClient.Settings.NumCharsGoal}");
         }
 
         #endregion
@@ -255,8 +260,10 @@ namespace StS2AP.UI
                 LogUtility.Warn($"[GoalTracker] Failed to load label font: {ex.Message}");
             }
 
-            // Placeholder text — will be replaced by SetContent() after injection
-            _contentLabel.Text = "[gold]Goal: Slay the Spire with X Characters\nProgress: 0 / 3";
+            // Font size is intentionally NOT set here — MegaRichTextLabel._Ready() fires when the
+            // node enters the tree and resets font size overrides. SetContent() applies it at runtime
+            // after _Ready() has already fired, matching the pattern in ArchipelagoCharTrackerUI.
+            _contentLabel.Text = "";
 
             panel.AddChild(_contentLabel);
 

--- a/client/StS2AP/UI/ArchipelagoGoalTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoGoalTrackerUI.cs
@@ -1,0 +1,280 @@
+﻿using Godot;
+using MegaCrit.Sts2.addons.mega_text;
+using StS2AP.Utils;
+using System;
+
+namespace StS2AP.UI
+{
+    /// <summary>
+    /// Static class that creates and manages the Archipelago Goal Tracker panel
+    /// on the Character Select screen.
+    ///
+    /// The panel is positioned in the bottom-left corner of the screen and contains
+    /// a single <see cref="MegaRichTextLabel"/> for displaying goal progress text.
+    ///
+    /// Injected and removed alongside <see cref="ArchipelagoCharTrackerUI"/> via the
+    /// <c>CharTrackerPanelPatches</c> in <c>Patches_MainMenuBehavior</c>.
+    /// </summary>
+    public static class ArchipelagoGoalTrackerUI
+    {
+        #region Node References
+
+        /// <summary>The root Control node added to the CanvasLayer.</summary>
+        private static Control? _rootPanel;
+
+        /// <summary>The CanvasLayer that hosts our panel so it renders on top of the scene.</summary>
+        private static CanvasLayer? _canvasLayer;
+
+        /// <summary>
+        /// The rich-text label inside the panel where goal content will be written.
+        /// Uses <see cref="MegaRichTextLabel"/> to support BBCode and the game's custom text effects.
+        /// </summary>
+        private static MegaRichTextLabel? _contentLabel;
+
+        #endregion
+
+        #region Constants
+
+        // The game font used throughout the mod for consistency
+        private const string FontPath = "res://fonts/kreon_regular.ttf";
+
+        // Font size for the goal text
+        private const int FontSize = 32;
+
+        // Padding inside the panel
+        private const float PanelPadding = 16f;
+
+        // Panel offsets — positioned in the bottom-left corner of the screen
+        private const float PanelLeftOffset   = 220f;
+        private const float PanelBottomOffset = 250f;
+
+        // Panel size — kept compact since it only holds a single label
+        private const float PanelWidth  = 400f;
+        private const float PanelHeight = 80f;
+
+        // Semi-transparent dark background matching ArchipelagoCharTrackerUI
+        private static readonly Color PanelBgColor = new Color(0.10f, 0.10f, 0.13f, 0.5f);
+
+        // CanvasLayer rendering order — same layer as ArchipelagoCharTrackerUI
+        private const int CanvasLayerIndex = 0;
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether the goal tracker panel is currently present and visible.
+        /// </summary>
+        public static bool IsVisible => _rootPanel?.Visible ?? false;
+
+        /// <summary>
+        /// Injects the goal tracker panel into the scene tree, creating it if it does not yet exist.
+        /// Safe to call multiple times — duplicate injection is ignored.
+        /// </summary>
+        public static void InjectUI()
+        {
+            try
+            {
+                var sceneTree = Engine.GetMainLoop() as SceneTree;
+                if (sceneTree == null)
+                {
+                    LogUtility.Error("[GoalTracker] Failed to get SceneTree — cannot inject goal tracker UI");
+                    return;
+                }
+
+                var root = sceneTree.Root;
+                if (root == null)
+                {
+                    LogUtility.Error("[GoalTracker] Failed to get root node — cannot inject goal tracker UI");
+                    return;
+                }
+
+                // Avoid rebuilding the UI if it is already present
+                if (_rootPanel != null && IsInstanceValid(_rootPanel))
+                {
+                    Show();
+                    return;
+                }
+
+                // Build and attach
+                _rootPanel = CreateUI();
+
+                _canvasLayer = new CanvasLayer();
+                _canvasLayer.Name = "ArchipelagoGoalTrackerLayer";
+                _canvasLayer.Layer = CanvasLayerIndex;
+                _canvasLayer.AddChild(_rootPanel);
+                root.AddChild(_canvasLayer);
+
+                LogUtility.Success("[GoalTracker] Archipelago goal-tracker UI injected successfully");
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Error($"[GoalTracker] Failed to inject goal tracker UI: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Removes the goal tracker panel from the scene tree entirely and resets all node references.
+        /// Called when the Character Select screen is closed.
+        /// </summary>
+        public static void RemoveUI()
+        {
+            if (_canvasLayer != null && IsInstanceValid(_canvasLayer))
+            {
+                _canvasLayer.QueueFree();
+                _canvasLayer  = null;
+                _rootPanel    = null;
+                _contentLabel = null;
+            }
+        }
+
+        /// <summary>
+        /// Makes the goal tracker panel visible.
+        /// </summary>
+        public static void Show()
+        {
+            if (_rootPanel != null && IsInstanceValid(_rootPanel))
+            {
+                _rootPanel.Visible = true;
+            }
+        }
+
+        /// <summary>
+        /// Hides the goal tracker panel without removing it from the tree.
+        /// </summary>
+        public static void Hide()
+        {
+            if (_rootPanel != null && IsInstanceValid(_rootPanel))
+            {
+                _rootPanel.Visible = false;
+            }
+        }
+
+        /// <summary>
+        /// Replaces the content displayed inside the goal tracker panel.
+        /// Supports full BBCode (including the game's custom [sine], [rainbow], etc. effects).
+        /// </summary>
+        /// <param name="bbcodeText">BBCode-formatted string to display.</param>
+        public static void SetContent(string bbcodeText)
+        {
+            if (_contentLabel != null && IsInstanceValid(_contentLabel))
+            {
+                // Re-apply the font size each time — the game sometimes resets theme overrides
+                _contentLabel.RemoveThemeFontSizeOverride("normal_font_size");
+                _contentLabel.AddThemeFontSizeOverride("normal_font_size", FontSize);
+
+                _contentLabel.Text = bbcodeText;
+            }
+        }
+
+        #endregion
+
+        #region UI Construction
+
+        /// <summary>
+        /// Builds the entire panel hierarchy from scratch.
+        ///
+        /// Layout (bottom-left anchored):
+        /// <code>
+        ///   Control (root, FullRect)
+        ///     └─ PanelContainer  ← semi-transparent background, fixed size, bottom-left anchor
+        ///          └─ MegaRichTextLabel  ← goal progress text
+        /// </code>
+        /// </summary>
+        private static Control CreateUI()
+        {
+            // ── Root ──────────────────────────────────────────────────────────────────
+            // Full-rect so anchors/offsets work relative to the full viewport.
+            var root = new Control();
+            root.Name = "ArchipelagoGoalTrackerUI";
+            root.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+            // Pass all mouse events through so we don't block game input
+            root.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // ── Panel ─────────────────────────────────────────────────────────────────
+            // Anchored to the bottom-left corner of the screen.
+            var panel = new PanelContainer();
+            panel.Name = "GoalTrackerPanel";
+            panel.CustomMinimumSize = new Vector2(PanelWidth, PanelHeight);
+
+            // Position: anchor bottom-left, then shift right by PanelLeftOffset and up by PanelBottomOffset.
+            panel.AnchorLeft   = 0f;
+            panel.AnchorRight  = 0f;
+            panel.AnchorTop    = 1f;
+            panel.AnchorBottom = 1f;
+
+            panel.OffsetLeft   = PanelLeftOffset;
+            panel.OffsetRight  = PanelLeftOffset + PanelWidth;
+            panel.OffsetTop    = -(PanelBottomOffset + PanelHeight);
+            panel.OffsetBottom = -PanelBottomOffset;
+
+            // Mouse passthrough — we don't need interaction on the goal tracker panel itself
+            panel.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // ── Background style ──────────────────────────────────────────────────────
+            // Matches the look of ArchipelagoCharTrackerUI: semi-transparent, slightly
+            // rounded corners, no visible border.
+            var panelStyle = new StyleBoxFlat();
+            panelStyle.BgColor = PanelBgColor;
+            panelStyle.SetBorderWidthAll(0);
+            panelStyle.SetCornerRadiusAll(10);
+            panelStyle.ContentMarginLeft   = PanelPadding;
+            panelStyle.ContentMarginRight  = PanelPadding;
+            panelStyle.ContentMarginTop    = PanelPadding;
+            panelStyle.ContentMarginBottom = PanelPadding;
+            panel.AddThemeStyleboxOverride("panel", panelStyle);
+
+            root.AddChild(panel);
+
+            // ── Content label ─────────────────────────────────────────────────────────
+            // Single MegaRichTextLabel for goal progress text with BBCode support.
+            _contentLabel = new MegaRichTextLabel();
+            _contentLabel.Name = "GoalTrackerLabel";
+            _contentLabel.SizeFlagsHorizontal = Control.SizeFlags.Fill;
+            _contentLabel.SizeFlagsVertical   = Control.SizeFlags.ShrinkCenter;
+            _contentLabel.FitContent          = true;
+            _contentLabel.AutowrapMode        = TextServer.AutowrapMode.Word;
+            _contentLabel.BbcodeEnabled       = true;
+            _contentLabel.MouseFilter         = Control.MouseFilterEnum.Ignore;
+
+            // Apply the game font so the text matches the rest of the UI
+            try
+            {
+                var font = GD.Load<Font>(FontPath);
+                if (font != null)
+                {
+                    _contentLabel.AddThemeFontOverride("normal_font", font);
+                }
+                else
+                {
+                    LogUtility.Warn($"[GoalTracker] Could not load font: {FontPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn($"[GoalTracker] Failed to load label font: {ex.Message}");
+            }
+
+            // Placeholder text — will be replaced by SetContent() after injection
+            _contentLabel.Text = "[gold]Goal: Slay the Spire with X Characters\nProgress: 0 / 3";
+
+            panel.AddChild(_contentLabel);
+
+            return root;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Checks whether a GodotObject instance is still valid (not null and not freed).
+        /// </summary>
+        private static bool IsInstanceValid(GodotObject obj)
+        {
+            return GodotObject.IsInstanceValid(obj);
+        }
+
+        #endregion
+    }
+}

--- a/client/StS2AP/UI/ArchipelagoGoalTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoGoalTrackerUI.cs
@@ -9,9 +9,6 @@ namespace StS2AP.UI
     /// Static class that creates and manages the Archipelago Goal Tracker panel
     /// on the Character Select screen.
     ///
-    /// The panel is positioned in the bottom-left corner of the screen and contains
-    /// a single <see cref="MegaRichTextLabel"/> for displaying goal progress text.
-    ///
     /// Injected and removed alongside <see cref="ArchipelagoCharTrackerUI"/> via the
     /// <c>CharTrackerPanelPatches</c> in <c>Patches_MainMenuBehavior</c>.
     /// </summary>
@@ -44,7 +41,7 @@ namespace StS2AP.UI
         // Padding inside the panel
         private const float PanelPadding = 16f;
 
-        // Panel offsets — positioned in the bottom-left corner of the screen
+        // Panel offsets — positioned in the bottom(ish)-left corner of the screen
         private const float PanelLeftOffset   = 220f;
         private const float PanelBottomOffset = 268f;
 
@@ -167,6 +164,9 @@ namespace StS2AP.UI
             }
         }
 
+        /// <summary>
+        /// Refreshes the goal progress text based on the current number of goal-achieved characters.
+        /// </summary>
         public static void UpdateGoalProgress()
         {
             SetContent($"[gold]Goal: Slay the Spire with {ArchipelagoClient.Settings.NumCharsGoal} Characters[/gold]\nProgress: {GameUtility.GoaledCharactersCount} / {ArchipelagoClient.Settings.NumCharsGoal}");
@@ -179,7 +179,7 @@ namespace StS2AP.UI
         /// <summary>
         /// Builds the entire panel hierarchy from scratch.
         ///
-        /// Layout (bottom-left anchored):
+        /// Layout:
         /// <code>
         ///   Control (root, FullRect)
         ///     └─ PanelContainer  ← semi-transparent background, fixed size, bottom-left anchor
@@ -188,26 +188,25 @@ namespace StS2AP.UI
         /// </summary>
         private static Control CreateUI()
         {
-            // ── Root ──────────────────────────────────────────────────────────────────
-            // Full-rect so anchors/offsets work relative to the full viewport.
+            // Root
             var root = new Control();
             root.Name = "ArchipelagoGoalTrackerUI";
             root.SetAnchorsPreset(Control.LayoutPreset.FullRect);
             // Pass all mouse events through so we don't block game input
             root.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-            // ── Panel ─────────────────────────────────────────────────────────────────
-            // Anchored to the bottom-left corner of the screen.
+            // Panel
             var panel = new PanelContainer();
             panel.Name = "GoalTrackerPanel";
             panel.CustomMinimumSize = new Vector2(PanelWidth, PanelHeight);
 
-            // Position: anchor bottom-left, then shift right by PanelLeftOffset and up by PanelBottomOffset.
+            // Anchor Positions
             panel.AnchorLeft   = 0f;
             panel.AnchorRight  = 0f;
             panel.AnchorTop    = 1f;
             panel.AnchorBottom = 1f;
 
+            // Offset Positions
             panel.OffsetLeft   = PanelLeftOffset;
             panel.OffsetRight  = PanelLeftOffset + PanelWidth;
             panel.OffsetTop    = -(PanelBottomOffset + PanelHeight);
@@ -216,9 +215,7 @@ namespace StS2AP.UI
             // Mouse passthrough — we don't need interaction on the goal tracker panel itself
             panel.MouseFilter = Control.MouseFilterEnum.Ignore;
 
-            // ── Background style ──────────────────────────────────────────────────────
-            // Matches the look of ArchipelagoCharTrackerUI: semi-transparent, slightly
-            // rounded corners, no visible border.
+            // Setup Background
             var panelStyle = new StyleBoxFlat();
             panelStyle.BgColor = PanelBgColor;
             panelStyle.SetBorderWidthAll(0);
@@ -231,8 +228,7 @@ namespace StS2AP.UI
 
             root.AddChild(panel);
 
-            // ── Content label ─────────────────────────────────────────────────────────
-            // Single MegaRichTextLabel for goal progress text with BBCode support.
+            // Content label
             _contentLabel = new MegaRichTextLabel();
             _contentLabel.Name = "GoalTrackerLabel";
             _contentLabel.SizeFlagsHorizontal = Control.SizeFlags.Fill;
@@ -260,9 +256,9 @@ namespace StS2AP.UI
                 LogUtility.Warn($"[GoalTracker] Failed to load label font: {ex.Message}");
             }
 
-            // Font size is intentionally NOT set here — MegaRichTextLabel._Ready() fires when the
-            // node enters the tree and resets font size overrides. SetContent() applies it at runtime
-            // after _Ready() has already fired, matching the pattern in ArchipelagoCharTrackerUI.
+            /// Font size is intentionally NOT set here — MegaRichTextLabel._Ready() fires when the
+            /// node enters the tree and resets font size overrides. SetContent() applies it at runtime
+            /// after _Ready() has already fired, matching the pattern in ArchipelagoCharTrackerUI.
             _contentLabel.Text = "";
 
             panel.AddChild(_contentLabel);

--- a/client/StS2AP/UI/Components/ItemCountLabel.cs
+++ b/client/StS2AP/UI/Components/ItemCountLabel.cs
@@ -1,0 +1,212 @@
+﻿using Godot;
+using MegaCrit.Sts2.addons.mega_text;
+using StS2AP.Utils;
+using System;
+
+namespace StS2AP.UI.Components
+{
+    /// <summary>
+    /// A reusable UI component that displays a small icon on the left and a
+    /// count/label string on the right, e.g. "(10 / 700)" or "42".
+    ///
+    /// Layout:
+    /// <code>
+    ///   HBoxContainer
+    ///     ├─ TextureRect  ← icon loaded from a res:// path
+    ///     └─ MegaRichTextLabel  ← BBCode count text
+    /// </code>
+    ///
+    /// Typical usage — build a vertical list in a parent VBoxContainer:
+    /// <code>
+    ///   var row = new ItemCountLabel("res://images/ui/gold.png", "[gold]50[/gold]");
+    ///   vbox.AddChild(row.Root);
+    /// </code>
+    /// </summary>
+    public class ItemCountLabel
+    {
+        #region Node References
+
+        /// <summary>
+        /// The root <see cref="HBoxContainer"/> node. Add this to your parent container.
+        /// </summary>
+        public HBoxContainer Root { get; }
+
+        /// <summary>The icon displayed on the left side of the row.</summary>
+        private readonly TextureRect _icon;
+
+        /// <summary>The text label displayed on the right side of the row.</summary>
+        private readonly MegaRichTextLabel _label;
+
+        #endregion
+
+        #region Constants
+
+        // Square size of the icon — kept small so rows stack tightly in a list
+        private const float IconSize = 30f;
+
+        // Gap between the icon and the text
+        private const int IconTextSpacing = 6;
+
+        // Font used for the label text, consistent with the rest of the mod UI
+        private const string FontPath = "res://fonts/kreon_regular.ttf";
+
+        // Default font size — callers can override via SetFontSize()
+        private const int DefaultFontSize = 20;
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Creates a new <see cref="ItemCountLabel"/> row.
+        /// </summary>
+        /// <param name="iconPath">
+        ///   A <c>res://</c> path to the icon texture, e.g.
+        ///   <c>"res://images/ui/items/gold.png"</c>.
+        ///   If the texture cannot be loaded a warning is logged and the icon slot is left empty.
+        /// </param>
+        /// <param name="text">
+        ///   Initial BBCode text for the count label, e.g. <c>"(10 / 700)"</c> or
+        ///   <c>"[gold]50 Gold[/gold]"</c>.  May be changed later via <see cref="SetText"/>.
+        /// </param>
+        /// <param name="fontSize">
+        ///   Optional font size override.  Defaults to <see cref="DefaultFontSize"/>.
+        /// </param>
+        public ItemCountLabel(string iconPath, string text, int fontSize = DefaultFontSize)
+        {
+            // ── Root row container ────────────────────────────────────────────────────
+            Root = new HBoxContainer();
+            Root.Name = "ItemCountLabel";
+            Root.AddThemeConstantOverride("separation", IconTextSpacing);
+            // Pass mouse events through — this is a display-only component
+            Root.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // ── Icon ─────────────────────────────────────────────────────────────────
+            _icon = new TextureRect();
+            _icon.Name = "ItemIcon";
+            _icon.CustomMinimumSize = new Vector2(IconSize, IconSize);
+            _icon.StretchMode = TextureRect.StretchModeEnum.KeepAspectCentered;
+            _icon.ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize;
+            // Align the icon vertically in the centre of the row
+            _icon.SizeFlagsVertical = Control.SizeFlags.ShrinkCenter;
+            _icon.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            try
+            {
+                var texture = GD.Load<Texture2D>(iconPath);
+                if (texture != null)
+                {
+                    _icon.Texture = texture;
+                }
+                else
+                {
+                    LogUtility.Warn($"[ItemCountLabel] Could not load icon texture: {iconPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn($"[ItemCountLabel] Failed to load icon texture '{iconPath}': {ex.Message}");
+            }
+
+            Root.AddChild(_icon);
+
+            // ── Label ─────────────────────────────────────────────────────────────────
+            // FitContent = true so the row height is driven by the text rather than
+            // collapsing to zero (same fix applied in ArchipelagoCharTrackerUI).
+            _label = new MegaRichTextLabel();
+            _label.Name = "ItemCountText";
+            _label.FitContent = true;
+            _label.BbcodeEnabled = true; // Required for BBCode and game text effects
+            _label.AutowrapMode = TextServer.AutowrapMode.Off; // Single-line counts don't need wrapping
+            _label.SizeFlagsHorizontal = Control.SizeFlags.Fill;
+            _label.SizeFlagsVertical = Control.SizeFlags.ShrinkCenter;
+            _label.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // Apply the game font, consistent with ArchipelagoNotificationUI and ArchipelagoCharTrackerUI
+            try
+            {
+                var font = GD.Load<Font>(FontPath);
+                if (font != null)
+                {
+                    _label.AddThemeFontOverride("normal_font", font);
+                }
+                else
+                {
+                    LogUtility.Warn($"[ItemCountLabel] Could not load font: {FontPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn($"[ItemCountLabel] Failed to load label font: {ex.Message}");
+            }
+
+            _label.AddThemeFontSizeOverride("normal_font_size", fontSize);
+            _label.Text = text;
+
+            Root.AddChild(_label);
+        }
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Replaces the count text displayed next to the icon.
+        /// Supports full BBCode (e.g. <c>"[gold](10 / 700)[/gold]"</c>).
+        /// </summary>
+        /// <param name="bbcodeText">New BBCode-formatted string to display.</param>
+        public void SetText(string bbcodeText)
+        {
+            if (GodotObject.IsInstanceValid(_label))
+            {
+                // Re-apply font size — the game can reset theme overrides unexpectedly
+                _label.RemoveThemeFontSizeOverride("normal_font_size");
+                _label.AddThemeFontSizeOverride("normal_font_size", DefaultFontSize);
+
+                _label.Text = bbcodeText;
+            }
+        }
+
+        /// <summary>
+        /// Swaps the icon texture at runtime, e.g. when the represented item type changes.
+        /// </summary>
+        /// <param name="iconPath">New <c>res://</c> path to the replacement texture.</param>
+        public void SetIcon(string iconPath)
+        {
+            if (!GodotObject.IsInstanceValid(_icon)) return;
+
+            try
+            {
+                var texture = GD.Load<Texture2D>(iconPath);
+                if (texture != null)
+                {
+                    _icon.Texture = texture;
+                }
+                else
+                {
+                    LogUtility.Warn($"[ItemCountLabel] Could not load replacement icon: {iconPath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn($"[ItemCountLabel] Failed to swap icon '{iconPath}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Overrides the font size on the label.
+        /// Useful when embedding this component at different visual scales.
+        /// </summary>
+        /// <param name="size">Font size in points.</param>
+        public void SetFontSize(int size)
+        {
+            if (GodotObject.IsInstanceValid(_label))
+            {
+                _label.RemoveThemeFontSizeOverride("normal_font_size");
+                _label.AddThemeFontSizeOverride("normal_font_size", size);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/client/StS2AP/UI/Components/ItemCountLabel.cs
+++ b/client/StS2AP/UI/Components/ItemCountLabel.cs
@@ -99,8 +99,8 @@ namespace StS2AP.UI.Components
             {
                 Root.MouseFilter = Control.MouseFilterEnum.Stop;
 
-                // Register the plain strings into a runtime loc table so HoverTip can look them up.
-                // The key is made unique per instance so multiple rows don't collide.
+                /// Register the plain strings into a runtime loc table so HoverTip can look them up.
+                /// The key is made unique per instance so multiple rows don't collide.
                 string tableKey = $"item_count_label_{tooltipTitle.GetHashCode():x}";
                 TextUtility.RegisterLocTableAtRuntime(tableKey, new System.Collections.Generic.Dictionary<string, string>
                 {
@@ -112,8 +112,8 @@ namespace StS2AP.UI.Components
                     new LocString(tableKey, "title"),
                     new LocString(tableKey, "description"));
 
-                // Show the tooltip when the mouse enters the row.
-                // Position it at the top center of the screen in a fixed position.
+                /// Show the tooltip when the mouse enters the row.
+                /// Position it at the top center of the screen in a fixed position.
                 Root.MouseEntered += () =>
                 {
                     try
@@ -184,9 +184,9 @@ namespace StS2AP.UI.Components
 
             Root.AddChild(_icon);
 
-            // ── Label ─────────────────────────────────────────────────────────────────
-            // FitContent = true so the row height is driven by the text rather than
-            // collapsing to zero (same fix applied in ArchipelagoCharTrackerUI).
+            /// ── Label ─────────────────────────────────────────────────────────────────
+            /// FitContent = true so the row height is driven by the text rather than
+            /// collapsing to zero (same fix applied in ArchipelagoCharTrackerUI).
             _label = new MegaRichTextLabel();
             _label.Name = "ItemCountText";
             _label.FitContent = true;

--- a/client/StS2AP/UI/Components/ItemCountLabel.cs
+++ b/client/StS2AP/UI/Components/ItemCountLabel.cs
@@ -113,16 +113,22 @@ namespace StS2AP.UI.Components
                     new LocString(tableKey, "description"));
 
                 // Show the tooltip when the mouse enters the row.
-                // Position it centered horizontally above the row — matching the
-                // manual positioning pattern used in ArchipelagoTopBarUI.
+                // Position it at the top center of the screen in a fixed position.
                 Root.MouseEntered += () =>
                 {
                     try
                     {
                         var tipSet = NHoverTipSet.CreateAndShow(Root, _hoverTip);
-                        tipSet.GlobalPosition = Root.GlobalPosition + new Vector2(
-                            (Root.Size.X - tipSet.Size.X) / 2f,
-                            -tipSet.Size.Y);
+                        
+                        // Get the viewport size to calculate screen center
+                        var viewportSize = Root.GetViewportRect().Size;
+                        
+                        // Position at top center of screen with a small margin from the top
+                        const float topMargin = 50f;
+                        const float offsetFromPanel = 140f;
+                        tipSet.GlobalPosition = new Vector2(
+                            offsetFromPanel + ((viewportSize.X - tipSet.Size.X) / 2f),  // Centered horizontally, then shifted from the progress panel
+                            topMargin);                              // Fixed distance from top
                     }
                     catch (Exception ex)
                     {

--- a/client/StS2AP/UI/Components/ItemCountLabel.cs
+++ b/client/StS2AP/UI/Components/ItemCountLabel.cs
@@ -101,8 +101,8 @@ namespace StS2AP.UI.Components
 
                 /// Register the plain strings into a runtime loc table so HoverTip can look them up.
                 /// The key is made unique per instance so multiple rows don't collide.
-                string tableKey = $"item_count_label_{tooltipTitle.GetHashCode():x}";
-                TextUtility.RegisterLocTableAtRuntime(tableKey, new System.Collections.Generic.Dictionary<string, string>
+                string tableKey = $"item_count_label_{Guid.NewGuid():N}";
+                TextUtility.RegisterLocTableAtRuntime(tableKey, new Dictionary<string, string>
                 {
                     { "title",       tooltipTitle       },
                     { "description", tooltipDescription }

--- a/client/StS2AP/UI/Components/ItemCountLabel.cs
+++ b/client/StS2AP/UI/Components/ItemCountLabel.cs
@@ -1,5 +1,8 @@
 ﻿using Godot;
 using MegaCrit.Sts2.addons.mega_text;
+using MegaCrit.Sts2.Core.HoverTips;
+using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Nodes.HoverTips;
 using StS2AP.Utils;
 using System;
 
@@ -37,6 +40,12 @@ namespace StS2AP.UI.Components
         /// <summary>The text label displayed on the right side of the row.</summary>
         private readonly MegaRichTextLabel _label;
 
+        /// <summary>
+        /// The hover tooltip shown when the player mouses over this row.
+        /// Null if no tooltip was provided — in that case mouse events pass through.
+        /// </summary>
+        private readonly HoverTip? _hoverTip;
+
         #endregion
 
         #region Constants
@@ -72,14 +81,73 @@ namespace StS2AP.UI.Components
         /// <param name="fontSize">
         ///   Optional font size override.  Defaults to <see cref="DefaultFontSize"/>.
         /// </param>
-        public ItemCountLabel(string iconPath, string text, int fontSize = DefaultFontSize)
+        /// <param name="tooltipTitle">
+        ///   Optional tooltip title shown on hover. Pass <c>null</c> to disable the tooltip entirely.
+        /// </param>
+        /// <param name="tooltipDescription">
+        ///   Optional tooltip description shown on hover. Pass <c>null</c> to disable the tooltip entirely.
+        /// </param>
+        public ItemCountLabel(string iconPath, string text, int fontSize = DefaultFontSize, string? tooltipTitle = null, string? tooltipDescription = null)
         {
             // ── Root row container ────────────────────────────────────────────────────
             Root = new HBoxContainer();
             Root.Name = "ItemCountLabel";
             Root.AddThemeConstantOverride("separation", IconTextSpacing);
-            // Pass mouse events through — this is a display-only component
-            Root.MouseFilter = Control.MouseFilterEnum.Ignore;
+
+            // If a tooltip is provided we need to receive mouse events; otherwise pass through.
+            if (tooltipTitle != null && tooltipDescription != null)
+            {
+                Root.MouseFilter = Control.MouseFilterEnum.Stop;
+
+                // Register the plain strings into a runtime loc table so HoverTip can look them up.
+                // The key is made unique per instance so multiple rows don't collide.
+                string tableKey = $"item_count_label_{tooltipTitle.GetHashCode():x}";
+                TextUtility.RegisterLocTableAtRuntime(tableKey, new System.Collections.Generic.Dictionary<string, string>
+                {
+                    { "title",       tooltipTitle       },
+                    { "description", tooltipDescription }
+                });
+
+                _hoverTip = new HoverTip(
+                    new LocString(tableKey, "title"),
+                    new LocString(tableKey, "description"));
+
+                // Show the tooltip when the mouse enters the row.
+                // Position it centered horizontally above the row — matching the
+                // manual positioning pattern used in ArchipelagoTopBarUI.
+                Root.MouseEntered += () =>
+                {
+                    try
+                    {
+                        var tipSet = NHoverTipSet.CreateAndShow(Root, _hoverTip);
+                        tipSet.GlobalPosition = Root.GlobalPosition + new Vector2(
+                            (Root.Size.X - tipSet.Size.X) / 2f,
+                            -tipSet.Size.Y);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogUtility.Warn($"[ItemCountLabel] Failed to show tooltip: {ex.Message}");
+                    }
+                };
+
+                // Remove the tooltip when the mouse leaves the row
+                Root.MouseExited += () =>
+                {
+                    try
+                    {
+                        NHoverTipSet.Remove(Root);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogUtility.Warn($"[ItemCountLabel] Failed to hide tooltip: {ex.Message}");
+                    }
+                };
+            }
+            else
+            {
+                // Pass mouse events through — this is a display-only component with no tooltip
+                Root.MouseFilter = Control.MouseFilterEnum.Ignore;
+            }
 
             // ── Icon ─────────────────────────────────────────────────────────────────
             _icon = new TextureRect();

--- a/client/StS2AP/Utils/GameUtility.cs
+++ b/client/StS2AP/Utils/GameUtility.cs
@@ -51,7 +51,9 @@ namespace StS2AP.Utils
         /// </summary>
         public static Dictionary<string, string> APSaves { get; set; } = new Dictionary<string, string>();
 
-
+        /// <summary>
+        /// Returns the Current Player's `APItemCharID`
+        /// </summary>
         public static APItemCharID? CurrentCharacterID
         {
             get
@@ -62,16 +64,26 @@ namespace StS2AP.Utils
                     return null;
                 }
                 var charName = CurrentPlayer.APName();
-                return charName switch
-                {
-                    "Ironclad" => APItemCharID.Ironclad,
-                    "Silent" => APItemCharID.Silent,
-                    "Defect" => APItemCharID.Defect,
-                    "Regent" => APItemCharID.Regent,
-                    "Necrobinder" => APItemCharID.Necrobinder,
-                    _ => null
-                };
+                return GetCharacterIDByName(charName);
             }
+        }
+
+        /// <summary>
+        /// Gets the `APItemCharID` for a character by their AP Name.
+        /// </summary>
+        /// <param name="name">The name of a character, as recognized by the Archipelago World. Usually found by calling `.APName()` on a `CharacterModel` or `Player`.</param>
+        /// <returns>The `APItemCharID` for a given character, by it's name. Returns `null` if the character name is invalid or unknown.</returns>
+        public static APItemCharID? GetCharacterIDByName(string name)
+        {
+            return name switch
+            {
+                "Ironclad" => APItemCharID.Ironclad,
+                "Silent" => APItemCharID.Silent,
+                "Defect" => APItemCharID.Defect,
+                "Regent" => APItemCharID.Regent,
+                "Necrobinder" => APItemCharID.Necrobinder,
+                _ => null
+            };
         }
 
         #region Receiving Items

--- a/client/StS2AP/Utils/GameUtility.cs
+++ b/client/StS2AP/Utils/GameUtility.cs
@@ -41,6 +41,16 @@ namespace StS2AP.Utils
         private static HashSet<string> _goaledCharacters = new HashSet<string>();
 
         /// <summary>
+        /// Whether or not the character has completed the run at least once, based on the local cache of goaled characters.
+        /// </summary>
+        /// <param name="charName">The name of the character to check. Please use `.APName()` from the `Player` or the `CharacterModel`</param>
+        /// <returns>True if the character has completed the run at least once, false otherwise.</returns>
+        public static bool HasCharacterGoaled(string charName)
+        {
+            return _goaledCharacters.Contains(charName);
+        }
+
+        /// <summary>
         /// Reference to the Current Player character.
         /// Set when a run starts, cleared when a run ends.
         /// </summary>

--- a/client/StS2AP/Utils/GameUtility.cs
+++ b/client/StS2AP/Utils/GameUtility.cs
@@ -41,6 +41,11 @@ namespace StS2AP.Utils
         private static HashSet<string> _goaledCharacters = new HashSet<string>();
 
         /// <summary>
+        /// The number of the characters that have reached their goal
+        /// </summary>
+        public static int GoaledCharactersCount => _goaledCharacters.Count;
+
+        /// <summary>
         /// Whether or not the character has completed the run at least once, based on the local cache of goaled characters.
         /// </summary>
         /// <param name="charName">The name of the character to check. Please use `.APName()` from the `Player` or the `CharacterModel`</param>


### PR DESCRIPTION
# Changes
- Created `ArchipelagoCharTrackerUI` which shows the locations checked and the items received for a given character. It's shown on the Character Select Screen.
- Created `ArchipelagoGoalTrackerUI` which shows your progress towards your goal. It's also shown on the Character Select Screen.
  - NOTE: There is a bug related to goals not syncing upon subsequent launches. It is not fixed in this PR, this will be the next thing I try to fix.

# Additional Changes
- Added `LocationData` which provides the ability to get location IDs for different location types (goldsanity, potionsanity, etc.)
- Added some extension methods for `CharacterModel`
- Added a few max constants for different location/item types in `ArchipelagoProgress`