### PR TITLE
fix: resolve character resource leak on stale reference

### DIFF
--- a/client/StS2AP/Patches/Patches_UnlockCharacters.cs
+++ b/client/StS2AP/Patches/Patches_UnlockCharacters.cs
@@ -142,13 +142,28 @@ namespace StS2AP.Patches
             /// </summary>
             public static void HandleCharacterUnlocked(NCharacterSelectScreen screen, APItemCharID charId)
             {
-                LogUtility.Debug($"HandleCharacterUnlocked: Received unlock event for charId={charId} on screen instance {screen?.GetInstanceId()}");
-
+                // Null check
                 if (screen == null)
                 {
                     LogUtility.Debug("HandleCharacterUnlocked: screen is null — ignoring");
                     return;
                 }
+
+                // Check if we're a stale handler (screen is disposed)
+                if (!GodotObject.IsInstanceValid(screen))
+                {
+                    // Remove this handler
+                    if (Handlers.TryGetValue(screen, out var handler))
+                    {
+                        ArchipelagoClient.CharacterUnlocked -= handler;
+                    }
+                    Handlers.Remove(screen);
+
+                    // And ignore the rest of the function
+                    return;
+                }
+
+                LogUtility.Debug($"HandleCharacterUnlocked: Received unlock event for charId={charId} on screen instance {screen?.GetInstanceId()}");
 
                 if (CharButtonContainerField.GetValue(screen) is not Control container)
                 {

--- a/client/StS2AP/UI/ArchipelagoTopBarUI.cs
+++ b/client/StS2AP/UI/ArchipelagoTopBarUI.cs
@@ -134,7 +134,7 @@ namespace StS2AP.UI
         /// <param name="count">The number of unclaimed rewards. Values above <see cref="MaxDisplayCount"/> are clamped.</param>
         public static void SetCount(int count)
         {
-            if (_countLabel == null) return;
+            if (_countLabel == null || !GodotObject.IsInstanceValid(_countLabel)) return;
 
             if (count <= 0)
             {


### PR DESCRIPTION
- Fix for #157 
- Also fixes a bug where getting a new character unlock, after you've already done at least one run, causes an error on the disposed top bar UI (RitsuLib will let us fix this at some point)