### PR TITLE
Beta main compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ You also need to:
 
 - Create a clone of Archipelago's repo should live in `../Archipelago` or Python will complain about the APWorld's `.py` files
 - Copy `client/StS2AP/local.props.template` to `client/StS2AP/local.props` and update `<STS2GamePath>` and `<GodotExePath>` to match your local installations
-  - `<STS2GamePath>` should point to the directory for the game in Steam
+  - `<STS2GamePath>` should point to the active Steam game directory used to launch the game and receive development builds
+  - For reproducible builds that support both game branches, uncomment `<STS2ReferenceDataDir>` and point it to a privately preserved Public Branch `0.107.1` `data_sts2_windows_x86_64` directory. This supplies `sts2.dll`, `0Harmony.dll`, and `GodotSharp.dll` at compile time even when the active Steam installation is on beta. Do not commit or distribute these game DLLs.
   - `<GodotExePath>` should point to the Godot Directory that has `Godot_v4.5.1-stable_mono_win64.exe`
 
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Archipelago Client & APWorld for STS2
 # Download the Latest Playable Release [Here](https://github.com/dlueben1/Slay-the-Spire-2-Archipelago/releases/latest)
 
 > [!IMPORTANT]
-> We do **not** support the Beta Branch, only the Public Branch of the game! There can be breaking changes to the underlying game's code that makes supporting beta branches unrealistic.
+> The client targets both the Public Branch (`0.107.1`) and the current Beta Branch.
 
 ## Alpha Development
 
@@ -16,7 +16,7 @@ This mod is currently in Alpha, and is unfinished. It's not feature-complete to 
 
 # Installing the Mod
 
-1. Ensure that you have [RitsuLib](https://steamcommunity.com/sharedfiles/filedetails/?id=3747602295) installed. The easiest way to obtain it is from Steam Workshop.
+1. Ensure that you have [RitsuLib](https://steamcommunity.com/sharedfiles/filedetails/?id=3747602295) installed from Steam Workshop. Its loader selects the RitsuLib build matching the active game API, so no reinstall is needed when switching between the Public and Beta branches.
 2. Download the "sts2-client.zip" from the [Releases](https://github.com/dlueben1/Slay-the-Spire-2-Archipelago/releases/latest) section of the Repo
 3. Go to your Slay the Spire II directory (In Steam, click "Browse Local Files")
 4. If a folder called `mods` does not exist, create it

--- a/client/StS2AP/ModEntry.cs
+++ b/client/StS2AP/ModEntry.cs
@@ -33,10 +33,6 @@ namespace StS2AP
 
             LogUtility.Info("Archipelago mod initializing...");
 
-            // Register the Death Link Curse's saved properties through the cache used by
-            // either the public branch or beta branch of the game.
-            BetaMainCompatibility.CacheSavedProperties(typeof(DeathLinkCurse));
-
             // Register with RitsuLib
             var assembly = Assembly.GetExecutingAssembly();
             ModTypeDiscoveryHub.RegisterModAssembly(ModId, assembly);

--- a/client/StS2AP/ModEntry.cs
+++ b/client/StS2AP/ModEntry.cs
@@ -7,7 +7,6 @@ using HarmonyLib;
 using MegaCrit.Sts2.Core.Modding;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Characters;
-using MegaCrit.Sts2.Core.Saves.Runs;
 using StS2AP.Models;
 using StS2AP.Utils;
 using STS2RitsuLib;
@@ -34,11 +33,9 @@ namespace StS2AP
 
             LogUtility.Info("Archipelago mod initializing...");
 
-            /// This lets StS know that there's a property on the Death Link Curse that needs to be saved/loaded with the save system.
-            /// This is done by injecting the type into the SavedPropertiesTypeCache.
-            ///
-            /// This also might change when we start using BaseLib. It probably makes this easier.
-            SavedPropertiesTypeCache.InjectTypeIntoCache(typeof(DeathLinkCurse));
+            // Register the Death Link Curse's saved properties through the cache used by
+            // either the public branch or beta branch of the game.
+            BetaMainCompatibility.CacheSavedProperties(typeof(DeathLinkCurse));
 
             // Register with RitsuLib
             var assembly = Assembly.GetExecutingAssembly();

--- a/client/StS2AP/Models/ArchipelagoProgress.cs
+++ b/client/StS2AP/Models/ArchipelagoProgress.cs
@@ -10,6 +10,7 @@ using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Ascension;
 using AscensionManager = StS2AP.Utils.AscensionManager;
+using System.Text.Json;
 
 
 namespace StS2AP.Models
@@ -461,9 +462,10 @@ namespace StS2AP.Models
 
         public SerializableAP ToSerializable(SerializableRun run)
         {
+            using var runJson = JsonDocument.Parse(JsonSerializationUtility.ToJson(run));
             return new SerializableAP()
             {
-                SaveData = run,
+                SaveData = runJson.RootElement.Clone(),
                 CardRewardsAttempted = CardRewardsAttempted,
                 RareCardRewardsAttempted = RareCardRewardsAttempted,
                 RelicRewardsAttempted = RelicRewardsAttempted,

--- a/client/StS2AP/Models/DeathLinkCurse.cs
+++ b/client/StS2AP/Models/DeathLinkCurse.cs
@@ -2,7 +2,7 @@
 using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.CardPools;
-using MegaCrit.Sts2.Core.Saves.Runs;
+using STS2RitsuLib.Utils;
 
 namespace StS2AP.Models
 {
@@ -12,11 +12,11 @@ namespace StS2AP.Models
     public sealed class DeathLinkCurse : CardModel
     {
         /// <summary>
-        /// A serializable message representing the DeathLink event that caused this Curse to be generated.
+        /// A saved message representing the DeathLink event that caused this Curse to be generated.
         /// This will be used in the card's description.
         /// </summary>
-        [SavedProperty]
-        public string DeathMessage { get; private set; } = string.Empty;
+        public static readonly SavedAttachedState<DeathLinkCurse, string> DeathMessage =
+            new("DeathMessage", _ => string.Empty);
 
         public DeathLinkCurse()
             : base(-1, CardType.Curse, CardRarity.Curse, TargetType.None)
@@ -70,7 +70,7 @@ namespace StS2AP.Models
         {
             base.AfterCloned();
             if (ArchipelagoClient.LastDeathLinkMessage != null)
-                DeathMessage = ArchipelagoClient.LastDeathLinkMessage;
+                DeathMessage[this] = ArchipelagoClient.LastDeathLinkMessage;
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace StS2AP.Models
         /// </summary>
         protected override void AddExtraArgsToDescription(LocString description)
         {
-            description.Add("death_message", DeathMessage);
+            description.Add("death_message", DeathMessage[this]);
         }
     }
 }

--- a/client/StS2AP/Models/SerializableAP.cs
+++ b/client/StS2AP/Models/SerializableAP.cs
@@ -13,7 +13,10 @@ namespace StS2AP.Models
     public class SerializableAP
     {
         [JsonPropertyName("save_data")]
-        public SerializableRun? SaveData { get; set; }
+        // Keep the base-game save opaque to AP's source-generated serializer. The
+        // running game must serialize and deserialize this payload with its own
+        // MegaCritSerializerContext so public and beta save schemas can differ.
+        public JsonElement? SaveData { get; set; }
         [JsonPropertyName("card_rewards_attempted")]
         public int CardRewardsAttempted { get; set; }
         [JsonPropertyName("rare_card_rewards_attempted")]

--- a/client/StS2AP/Patches/Patches_SaveManagement.cs
+++ b/client/StS2AP/Patches/Patches_SaveManagement.cs
@@ -163,13 +163,15 @@ namespace StS2AP.Patches
                         var unzipped = Patches_RunSaveManager.SaveRun.Unzip(saveStr);
                         //LogUtility.Info($"JSON Save data{unzipped}");
                         SerializableAP? result = JsonSerializer.Deserialize<SerializableAP>(unzipped, SerializationUtility.CombinedOptions);
-                        if (result?.SaveData is not JsonElement saveData)
+                        JsonElement? saveData = result?.SaveData;
+                        if (result == null || saveData == null ||
+                            saveData.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
                         {
                             LogUtility.Error("Failed to load AP save: save_data was missing");
                             NotificationUtility.ShowRawText("Failed to load checkpoint. The checkpoint was preserved.");
                             return;
                         }
-                        ReadSaveResult<SerializableRun> runResult = JsonSerializationUtility.FromJson<SerializableRun>(saveData.GetRawText());
+                        ReadSaveResult<SerializableRun> runResult = JsonSerializationUtility.FromJson<SerializableRun>(saveData.Value.GetRawText());
                         if (!runResult.Success || runResult.SaveData == null)
                         {
                             LogUtility.Error($"Failed to deserialize AP run save: {runResult.ErrorMessage ?? runResult.Status.ToString()}");

--- a/client/StS2AP/Patches/Patches_SaveManagement.cs
+++ b/client/StS2AP/Patches/Patches_SaveManagement.cs
@@ -119,7 +119,7 @@ namespace StS2AP.Patches
             public static bool intercept(NCharacterSelectScreen __instance)
             {
 
-                var charName = __instance.Lobby.LocalPlayer.character.Id.Entry;
+                var charName = BetaMainCompatibility.GetLocalCharacter(__instance.Lobby).Id.Entry;
                 foreach(var entry in GameUtility.APSaves)
                 {
                     if (entry.Value.Length > 0)
@@ -157,7 +157,7 @@ namespace StS2AP.Patches
                 {
                     NAudioManager.Instance?.StopMusic();
                     string saveStr;
-                    var charName = _charSelect.Lobby.LocalPlayer.character.Id.Entry;
+                    var charName = BetaMainCompatibility.GetLocalCharacter(_charSelect.Lobby).Id.Entry;
                     if (GameUtility.APSaves.TryGetValue(charName, out saveStr))
                     {
                         var unzipped = Patches_RunSaveManager.SaveRun.Unzip(saveStr);

--- a/client/StS2AP/Patches/Patches_SaveManagement.cs
+++ b/client/StS2AP/Patches/Patches_SaveManagement.cs
@@ -55,7 +55,7 @@ namespace StS2AP.Patches
                     return false;
                 }
 
-                LogUtility.Info("Saving to AP");
+                LogUtility.Info("Preparing AP checkpoint save");
                 SerializableRun saveMe = RunManager.Instance.ToSave(preFinishedRoom);
                 __result = asyncSave(saveMe);
                 return false;
@@ -163,13 +163,20 @@ namespace StS2AP.Patches
                         var unzipped = Patches_RunSaveManager.SaveRun.Unzip(saveStr);
                         //LogUtility.Info($"JSON Save data{unzipped}");
                         SerializableAP? result = JsonSerializer.Deserialize<SerializableAP>(unzipped, SerializationUtility.CombinedOptions);
-                        if (result == null)
+                        if (result?.SaveData is not JsonElement saveData)
                         {
-                            LogUtility.Error($"Failed to load save");
-                            _charSelect.Lobby.SetReady(ready: true);
+                            LogUtility.Error("Failed to load AP save: save_data was missing");
+                            NotificationUtility.ShowRawText("Failed to load checkpoint. The checkpoint was preserved.");
                             return;
                         }
-                        SerializableRun serializableRun = result.SaveData;
+                        ReadSaveResult<SerializableRun> runResult = JsonSerializationUtility.FromJson<SerializableRun>(saveData.GetRawText());
+                        if (!runResult.Success || runResult.SaveData == null)
+                        {
+                            LogUtility.Error($"Failed to deserialize AP run save: {runResult.ErrorMessage ?? runResult.Status.ToString()}");
+                            NotificationUtility.ShowRawText("Failed to load checkpoint. The checkpoint was preserved.");
+                            return;
+                        }
+                        SerializableRun serializableRun = runResult.SaveData;
                         RunState runState = RunState.FromSerializable(serializableRun);
                         await RunManager.Instance.SetUpSavedSingleplayer(runState, serializableRun);
                         Log.Info($"Continuing run with character: {serializableRun.Players[0].CharacterId}");
@@ -189,10 +196,12 @@ namespace StS2AP.Patches
                 }
                 catch (Exception ex)
                 {
-                    LogUtility.Error($"Failed to load AP save: {ex.Message}");
+                    LogUtility.Error($"Failed to load AP save: {ex}");
+                    NotificationUtility.ShowRawText("Failed to load checkpoint. The checkpoint was preserved.");
+                    return;
                 }
-                LogUtility.Error("Somehow got here, but we don't have a save, starting the run");
-                _charSelect.Lobby.SetReady(ready: true);
+                LogUtility.Error("AP save disappeared before it could be loaded; preserving the current run selection");
+                NotificationUtility.ShowRawText("The checkpoint could not be found.");
             }
         }
 

--- a/client/StS2AP/StS2AP.csproj
+++ b/client/StS2AP/StS2AP.csproj
@@ -28,6 +28,7 @@
 		<!-- Derived paths -->
 		<ModsOutputDir>$(STS2GamePath)\mods\$(ModName)</ModsOutputDir>
 		<GameDataDir>$(STS2GamePath)\data_sts2_windows_x86_64</GameDataDir>
+		<STS2ReferenceDataDir Condition="'$(STS2ReferenceDataDir)' == ''">$(GameDataDir)</STS2ReferenceDataDir>
 		<GodotProject>$(ProjectDir)godot</GodotProject>
 	</PropertyGroup>
 
@@ -38,13 +39,13 @@
 
 	<ItemGroup>
 		<Reference Include="0Harmony">
-			<HintPath>$(GameDataDir)\0Harmony.dll</HintPath>
+			<HintPath>$(STS2ReferenceDataDir)\0Harmony.dll</HintPath>
 		</Reference>
 		<Reference Include="GodotSharp">
-			<HintPath>$(GameDataDir)\GodotSharp.dll</HintPath>
+			<HintPath>$(STS2ReferenceDataDir)\GodotSharp.dll</HintPath>
 		</Reference>
 		<Reference Include="sts2">
-			<HintPath>$(GameDataDir)\sts2.dll</HintPath>
+			<HintPath>$(STS2ReferenceDataDir)\sts2.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/client/StS2AP/Utils/BetaMainCompatibility.cs
+++ b/client/StS2AP/Utils/BetaMainCompatibility.cs
@@ -1,0 +1,71 @@
+﻿using HarmonyLib;
+using MegaCrit.Sts2.Core.Models;
+
+namespace StS2AP.Utils;
+
+/// <summary>
+/// Bridges game API differences between the public 0.107.1 branch and newer beta branches.
+/// Keep direct references to renamed or removed game types inside this reflection boundary.
+/// </summary>
+public static class BetaMainCompatibility
+{
+    private const string MainSaveCacheTypeName =
+        "MegaCrit.Sts2.Core.Saves.Runs.SavedPropertiesTypeCache";
+
+    private const string BetaSaveCacheTypeName =
+        "MegaCrit.Sts2.Core.Multiplayer.Serialization.ModelIdSerializationCache";
+
+    /// <summary>
+    /// Registers a model type containing saved properties with either the public-branch
+    /// SavedPropertiesTypeCache or the beta-branch ModelIdSerializationCache.
+    /// </summary>
+    public static void CacheSavedProperties(Type modelType)
+    {
+        // The public branch and beta branch moved this cache to different types.
+        // Resolve by capability so this assembly does not bind to either cache type directly.
+        Type cacheType = AccessTools.TypeByName(MainSaveCacheTypeName)
+            ?? AccessTools.TypeByName(BetaSaveCacheTypeName)
+            ?? throw new TypeLoadException(
+                $"Could not find {MainSaveCacheTypeName} or {BetaSaveCacheTypeName}."
+            );
+
+        // Public 0.107.1 takes only the model type. The beta method added two context
+        // parameters; BaseLib passes null for both when registering a standalone mod type.
+        object?[] arguments = cacheType.FullName == MainSaveCacheTypeName
+            ? [modelType]
+            : [modelType, null, null];
+
+        // CachePropertiesForType is private in the game, so use Harmony's reflection helper.
+        var cacheMethod = AccessTools.Method(cacheType, "CachePropertiesForType")
+            ?? throw new MissingMethodException(cacheType.FullName, "CachePropertiesForType");
+
+        cacheMethod.Invoke(null, arguments);
+        LogUtility.Info(
+            $"Registered saved properties for {modelType.FullName} through " +
+            $"{cacheType.Name}.{cacheMethod.Name}."
+        );
+    }
+
+    /// <summary>
+    /// Gets the selected local character without binding to LobbyPlayer, which was renamed
+    /// to StartRunLobbyPlayer on the beta branch and changed StartRunLobby.LocalPlayer's
+    /// binary return type.
+    /// </summary>
+    public static CharacterModel GetLocalCharacter(object lobby)
+    {
+        ArgumentNullException.ThrowIfNull(lobby);
+
+        // LocalPlayer's declared return type changed from LobbyPlayer to
+        // StartRunLobbyPlayer. Calling the property directly would bind this mod to
+        // whichever return type was present in the sts2.dll used for compilation.
+        object localPlayer = AccessTools.Property(lobby.GetType(), "LocalPlayer")?.GetValue(lobby)
+            ?? throw new MissingMemberException(lobby.GetType().FullName, "LocalPlayer");
+
+        // Both player types retain the same character field, so only the containing
+        // player type needs to be resolved at runtime.
+        return AccessTools.Field(localPlayer.GetType(), "character")?.GetValue(localPlayer) as CharacterModel
+            ?? throw new InvalidCastException(
+                $"Could not read a {nameof(CharacterModel)} from {localPlayer.GetType().FullName}.character."
+            );
+    }
+}

--- a/client/StS2AP/Utils/BetaMainCompatibility.cs
+++ b/client/StS2AP/Utils/BetaMainCompatibility.cs
@@ -9,43 +9,6 @@ namespace StS2AP.Utils;
 /// </summary>
 public static class BetaMainCompatibility
 {
-    private const string MainSaveCacheTypeName =
-        "MegaCrit.Sts2.Core.Saves.Runs.SavedPropertiesTypeCache";
-
-    private const string BetaSaveCacheTypeName =
-        "MegaCrit.Sts2.Core.Multiplayer.Serialization.ModelIdSerializationCache";
-
-    /// <summary>
-    /// Registers a model type containing saved properties with either the public-branch
-    /// SavedPropertiesTypeCache or the beta-branch ModelIdSerializationCache.
-    /// </summary>
-    public static void CacheSavedProperties(Type modelType)
-    {
-        // The public branch and beta branch moved this cache to different types.
-        // Resolve by capability so this assembly does not bind to either cache type directly.
-        Type cacheType = AccessTools.TypeByName(MainSaveCacheTypeName)
-            ?? AccessTools.TypeByName(BetaSaveCacheTypeName)
-            ?? throw new TypeLoadException(
-                $"Could not find {MainSaveCacheTypeName} or {BetaSaveCacheTypeName}."
-            );
-
-        // Public 0.107.1 takes only the model type. The beta method added two context
-        // parameters; BaseLib passes null for both when registering a standalone mod type.
-        object?[] arguments = cacheType.FullName == MainSaveCacheTypeName
-            ? [modelType]
-            : [modelType, null, null];
-
-        // CachePropertiesForType is private in the game, so use Harmony's reflection helper.
-        var cacheMethod = AccessTools.Method(cacheType, "CachePropertiesForType")
-            ?? throw new MissingMethodException(cacheType.FullName, "CachePropertiesForType");
-
-        cacheMethod.Invoke(null, arguments);
-        LogUtility.Info(
-            $"Registered saved properties for {modelType.FullName} through " +
-            $"{cacheType.Name}.{cacheMethod.Name}."
-        );
-    }
-
     /// <summary>
     /// Gets the selected local character without binding to LobbyPlayer, which was renamed
     /// to StartRunLobbyPlayer on the beta branch and changed StartRunLobby.LocalPlayer's

--- a/client/StS2AP/Utils/DeathLinkUtility.cs
+++ b/client/StS2AP/Utils/DeathLinkUtility.cs
@@ -68,7 +68,7 @@ namespace StS2AP.Utils
 
             try
             {
-                // Permanently adds a clone (with the SavedProperty stamped) to the deck
+                // Permanently adds a clone with its saved attached state to the deck
                 await CardPileCmd.AddCursesToDeck(
                     new[] { ModelDb.Card<DeathLinkCurse>() },
                     GameUtility.CurrentPlayer!

--- a/client/StS2AP/local.props.template
+++ b/client/StS2AP/local.props.template
@@ -6,6 +6,7 @@
     <!--
       Optional compile-time reference directory. For reproducible cross-branch release builds,
       point this at a preserved Public Branch 0.107.1 data_sts2_windows_x86_64 directory.
+      I recommend, copying that directory on main branch so you can better test the beta branch 
       If omitted, the build uses the active installation under STS2GamePath.
     -->
     <!-- <STS2ReferenceDataDir>???\sts2-reference\0.107.1\data_sts2_windows_x86_64</STS2ReferenceDataDir> -->

--- a/client/StS2AP/local.props.template
+++ b/client/StS2AP/local.props.template
@@ -1,13 +1,22 @@
 <Project>
   <PropertyGroup>
-    <!-- Paths - Update these with the absolute paths to your Slay the Spire 2 Steam App and Godot Executable -->
+    <!-- Active game installation used for debugging and deploying the built mod. -->
     <STS2GamePath>???\steamapps\common\Slay the Spire 2</STS2GamePath>
+
+    <!--
+      Optional compile-time reference directory. For reproducible cross-branch release builds,
+      point this at a preserved Public Branch 0.107.1 data_sts2_windows_x86_64 directory.
+      If omitted, the build uses the active installation under STS2GamePath.
+    -->
+    <!-- <STS2ReferenceDataDir>???\sts2-reference\0.107.1\data_sts2_windows_x86_64</STS2ReferenceDataDir> -->
+
+    <!-- Godot 4.5.1 .NET executable used to export the mod's PCK. -->
     <GodotExePath>???\Godot_v4.5.1-stable_mono_win64.exe</GodotExePath>
     
     <!-- Mod Metadata -->
     <ModName>Archipelago</ModName>
     <ModDisplayName>Archipelago Client</ModDisplayName>
     <ModAuthor>Kirbyfanner</ModAuthor>
-    <ModVersion>0.0.1</ModVersion>
+    <ModVersion>0.5.3</ModVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The mod allows compatibility between the beta branch and main branch of the game.
So one mod compilation (by compiling against the main branch) can work on both the beta and main branch.
So this should allow it to be suitable to put on the steam workshop instead of maintaining 2 different mod versions.

**I do not mind taking responsibility for ensuring beta-main compatibility in the future.**

### Dependencies:
RitsuLib on the steam workshop uses it's variant-pack which automatically loads the correct version of RitsuLib automatically so we don't need to worry about that.

## Key Fixes:
- Use RitsuLib's SavedAttachedState instead of SavedPropertyType's directly, used for Deathlink Settings (basically leverage RitsuLib's ability to do compatibility for us). This solves the discrepancy introduced by Beta Patch v0.109.0
- Have to do some 'hacky' Runtime Serialization for MegaCrit's SerializableRun to allow compilation on main branch but saves still supporting beta branch. This is due to them changing the PlayerRng's representation in Beta Patch V0.108.0. Basically move parts of Serialization to Runtime instead of Compile time. I could see us having to do hacky stuff like this if MegaCrit changes other in-game representations we use.
- Fixes the LocalPlayerReady differences introduced by Beta Patch V0.110.0. I mainly took inspiration from BaseLib's and their diffs on the BetaMainCompatibility.CS

## Caveats:
- An AP Save created on the main branch and then mid AP run, switch branches to the beta branch. The game will ask you to load a save which will fail (notification will appear) but otherwise still allows the player to play. Perhaps the behaviour should indicate what version the save was on or to not indicate loading a save at all.

