### PR TITLE
Add support for Progressive Starter Card and Progressive Starter Relic

### DIFF
--- a/client/StS2AP/ArchipelagoClient.cs
+++ b/client/StS2AP/ArchipelagoClient.cs
@@ -782,6 +782,14 @@ namespace StS2AP
 
                     break;
                 }
+                case APItem.ProgressiveStarterCard:
+                    HandleThreshholdItem(item, Progress.ProgressiveStarterCards, "Progressive Starter Cards");
+                    ProgressiveStarterUtility.QueueReconcileCurrentPlayer();
+                    break;
+                case APItem.ProgressiveStarterRelic:
+                    HandleThreshholdItem(item, Progress.ProgressiveStarterRelics, "Progressive Starter Relics");
+                    ProgressiveStarterUtility.QueueReconcileCurrentPlayer();
+                    break;
                 // Gold is condensed into a single reward pool
                 case APItem.OneGold:
                 case APItem.FiveGold:
@@ -1075,6 +1083,11 @@ namespace StS2AP
 
             if (slotData.ContainsKey("include_floor_checks"))
                 settings.Floorsanity = Convert.ToInt32(slotData["include_floor_checks"]) != 0;
+
+            settings.ProgressiveStarterCard =
+                Convert.ToInt32(slotData["progressive_starter_card"]) != 0;
+            settings.ProgressiveStarterRelic =
+                Convert.ToInt32(slotData["progressive_starter_relic"]) != 0;
 
             if (slotData.ContainsKey("shop_sanity"))
                 settings.ShopSanity = Convert.ToInt32(slotData["shop_sanity"]) != 0;

--- a/client/StS2AP/Data/ItemTable.cs
+++ b/client/StS2AP/Data/ItemTable.cs
@@ -40,6 +40,8 @@ namespace StS2AP.Data
             ToughEnemies = 26,
             DeadlyEnemies = 27,
             DoubleBoss = 28,
+            ProgressiveStarterCard = 29,
+            ProgressiveStarterRelic = 30,
 
             /// ── Ephemeral Buff items (universal / character-agnostic) ──────────────────
             /// These are one-time-use filler items that apply a temporary in-combat buff
@@ -93,6 +95,8 @@ namespace StS2AP.Data
             { 26, "Disable Tough Enemies" },
             { 27, "Disable Deadly Enemies" },
             { 28, "Disable Double Boss" },
+            { 29, "Progressive Starter Card" },
+            { 30, "Progressive Starter Relic" },
             { 500, "Free Attack" },
             { 501, "Free Power" },
             { 502, "Free Skill" },
@@ -141,6 +145,8 @@ namespace StS2AP.Data
               case APItem.ShopRelicSlot:
               case APItem.ShopPotionSlot:
               case APItem.ProgressiveShopRemove:
+              case APItem.ProgressiveStarterCard:
+              case APItem.ProgressiveStarterRelic:
                     return false;
               case APItem.Unlock:
                     return false;

--- a/client/StS2AP/Models/ArchipelagoProgress.cs
+++ b/client/StS2AP/Models/ArchipelagoProgress.cs
@@ -326,6 +326,12 @@ namespace StS2AP.Models
             PotionAssignments.Clear();
             Ascensions.Reset();
             GoldRedeemed = 0;
+            ProgressiveStarterCardBaseId = null;
+            ProgressiveStarterCardUpgradedId = null;
+            ProgressiveStarterCardTier = ProgressiveStarterTier.Unsupported;
+            ProgressiveStarterRelicBaseId = null;
+            ProgressiveStarterRelicUpgradedId = null;
+            ProgressiveStarterRelicTier = ProgressiveStarterTier.Unsupported;
         }
 
 
@@ -491,6 +497,26 @@ namespace StS2AP.Models
         public Dictionary<long, int> ProgressiveAncients = new Dictionary<long, int>();
 
         /// <summary>
+        /// Counts the Progressive Starter Card and Relic items received for each character.
+        /// These are reconstructed from the Archipelago item history when a save is loaded.
+        /// </summary>
+        public Dictionary<long, int> ProgressiveStarterCards = new Dictionary<long, int>();
+        public Dictionary<long, int> ProgressiveStarterRelics = new Dictionary<long, int>();
+
+        /// <summary>
+        /// The Orobas-recognized starter models and authoritative applied tiers for the active run.
+        /// The IDs must be saved because tier zero removes the models that would otherwise be
+        /// rediscovered for modded characters. Keeping the tier separately distinguishes that state
+        /// from a player or another mod removing an already-unlocked starter.
+        /// </summary>
+        public string? ProgressiveStarterCardBaseId { get; set; }
+        public string? ProgressiveStarterCardUpgradedId { get; set; }
+        public ProgressiveStarterTier ProgressiveStarterCardTier { get; set; } = ProgressiveStarterTier.Unsupported;
+        public string? ProgressiveStarterRelicBaseId { get; set; }
+        public string? ProgressiveStarterRelicUpgradedId { get; set; }
+        public ProgressiveStarterTier ProgressiveStarterRelicTier { get; set; } = ProgressiveStarterTier.Unsupported;
+
+        /// <summary>
         /// Gets the highest Act that a character can rest at
         /// </summary>
         /// <param name="character">The Character's offset</param>
@@ -575,6 +601,12 @@ namespace StS2AP.Models
                         kv.Value.Select(relic => (relic.IsMutable ? relic : relic.ToMutable()).ToSerializable()).ToList()
                     )
                 ).ToDictionary(),
+                ProgressiveStarterCardBaseId = ProgressiveStarterCardBaseId,
+                ProgressiveStarterCardUpgradedId = ProgressiveStarterCardUpgradedId,
+                ProgressiveStarterCardTier = ProgressiveStarterCardTier,
+                ProgressiveStarterRelicBaseId = ProgressiveStarterRelicBaseId,
+                ProgressiveStarterRelicUpgradedId = ProgressiveStarterRelicUpgradedId,
+                ProgressiveStarterRelicTier = ProgressiveStarterRelicTier,
                 CardAssignments = CardAssignments.Select((KeyValuePair<int, CardReward> kv) => new KeyValuePair<int, SerializableReward>(kv.Key, kv.Value.ToSerializable())).ToDictionary(),
                 CardAssignmentModels = CardAssignments.Select((KeyValuePair<int, CardReward> kv) =>
                 new KeyValuePair<int, List<SerializableCard>>(kv.Key, kv.Value.Cards.Select(c => c.ToSerializable()).ToList())).ToDictionary(),
@@ -608,6 +640,12 @@ namespace StS2AP.Models
                         kv.Value.Select(RelicModel.FromSerializable).ToList()
                     )
                 ).ToDictionary(),
+                ProgressiveStarterCardBaseId = saveData.ProgressiveStarterCardBaseId,
+                ProgressiveStarterCardUpgradedId = saveData.ProgressiveStarterCardUpgradedId,
+                ProgressiveStarterCardTier = saveData.ProgressiveStarterCardTier,
+                ProgressiveStarterRelicBaseId = saveData.ProgressiveStarterRelicBaseId,
+                ProgressiveStarterRelicUpgradedId = saveData.ProgressiveStarterRelicUpgradedId,
+                ProgressiveStarterRelicTier = saveData.ProgressiveStarterRelicTier,
                 PotionAssignments = saveData.PotionAssignments.Select((KeyValuePair<int, SerializablePotion> kv) => new KeyValuePair<int, PotionModel>(kv.Key, PotionModel.FromSerializable(kv.Value).CanonicalInstance)).ToDictionary(),
             };
 

--- a/client/StS2AP/Models/ArchipelagoSettings.cs
+++ b/client/StS2AP/Models/ArchipelagoSettings.cs
@@ -89,6 +89,8 @@ namespace StS2AP.Models
         public bool GoldSanity { get; set; }
         public bool PotionSanity { get; set; }
         public bool Floorsanity { get; set; }
+        public bool ProgressiveStarterCard { get; set; }
+        public bool ProgressiveStarterRelic { get; set; }
 
         #region Shop Sanity Settings
 

--- a/client/StS2AP/Models/ProgressiveStarterTier.cs
+++ b/client/StS2AP/Models/ProgressiveStarterTier.cs
@@ -1,0 +1,10 @@
+namespace StS2AP.Models
+{
+    public enum ProgressiveStarterTier
+    {
+        Unsupported = -1,
+        None = 0,
+        Basic = 1,
+        Upgraded = 2,
+    }
+}

--- a/client/StS2AP/Models/SerializableAP.cs
+++ b/client/StS2AP/Models/SerializableAP.cs
@@ -43,6 +43,18 @@ namespace StS2AP.Models
         public List<int> UsedItems { get; set; } = new List<int>();
         [JsonPropertyName("gold_redeemed")]
         public int GoldRedeemed { get; set; }
+        [JsonPropertyName("progressive_starter_card_base_id")]
+        public string? ProgressiveStarterCardBaseId { get; set; }
+        [JsonPropertyName("progressive_starter_card_upgraded_id")]
+        public string? ProgressiveStarterCardUpgradedId { get; set; }
+        [JsonPropertyName("progressive_starter_card_tier")]
+        public ProgressiveStarterTier ProgressiveStarterCardTier { get; set; } = ProgressiveStarterTier.Unsupported;
+        [JsonPropertyName("progressive_starter_relic_base_id")]
+        public string? ProgressiveStarterRelicBaseId { get; set; }
+        [JsonPropertyName("progressive_starter_relic_upgraded_id")]
+        public string? ProgressiveStarterRelicUpgradedId { get; set; }
+        [JsonPropertyName("progressive_starter_relic_tier")]
+        public ProgressiveStarterTier ProgressiveStarterRelicTier { get; set; } = ProgressiveStarterTier.Unsupported;
         public List<int> Ascensions { get; set; } = new List<int>();
     }
 

--- a/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
+++ b/client/StS2AP/Patches/Patches_APProgressOnCharSelect.cs
@@ -152,6 +152,12 @@ namespace StS2AP.Patches
                 ArchipelagoCharTrackerUI.ProgressiveSmithLabel?.SetText($"({ArchipelagoClient.Progress.MaxSmithLevel(offset) ?? 0} / 3)");
                 ArchipelagoCharTrackerUI.ProgressiveAncients?.SetText($"{ArchipelagoClient.Progress.MaxProgressiveAncientLevel(offset)} / 3");
 
+                ArchipelagoClient.Progress.ProgressiveStarterCards.TryGetValue(offset, out int starterCardTier);
+                ArchipelagoCharTrackerUI.ProgressiveStarterCardLabel?.SetText($"({starterCardTier} / 2)");
+
+                ArchipelagoClient.Progress.ProgressiveStarterRelics.TryGetValue(offset, out int starterRelicTier);
+                ArchipelagoCharTrackerUI.ProgressiveStarterRelicLabel?.SetText($"({starterRelicTier} / 2)");
+
                 // Count Card/Relic/Potion/Progressive Rewards
                 var itemCounts = ArchipelagoClient.Progress.AllReceivedItems
                     .Where(i => i.Item.GetCharacterOffset() == offset)

--- a/client/StS2AP/Patches/Patches_AncientRelics.cs
+++ b/client/StS2AP/Patches/Patches_AncientRelics.cs
@@ -4,6 +4,8 @@ using MegaCrit.Sts2.Core.Commands;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.HoverTips;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Events;
+using MegaCrit.Sts2.Core.Models.Relics;
 using MegaCrit.Sts2.Core.Nodes.Rooms;
 using StS2AP.Extensions;
 using StS2AP.Models;
@@ -14,6 +16,157 @@ using System.Linq;
 
 namespace StS2AP.Patches
 {
+    /// <summary>
+    /// Removes the vanilla Orobas upgrade relics that would bypass progressive starter tiers.
+    /// Orobas normally takes one option from each of three pools. If its pool-three upgrade relics
+    /// are blocked or unavailable, the third choice comes from the remaining first two pools.
+    /// A future advanced-Ancient pool implementation must apply the same exclusions to its pool.
+    /// </summary>
+    [HarmonyPatch(typeof(Orobas), "GenerateInitialOptions")]
+    internal static class Patches_OrobasProgressiveStarters
+    {
+        [HarmonyPrefix]
+        private static bool Prefix(Orobas __instance, ref IReadOnlyList<EventOption> __result)
+        {
+            if (__instance.Owner is null || !ShouldFilterProgressiveStarters())
+                return true;
+
+            try
+            {
+                var currentCharacter = __instance.Owner.Character;
+                var seaGlassCharacter = __instance.Rng.NextItem(
+                    __instance.Owner.UnlockState.Characters.Where(character =>
+                        character.Id != currentCharacter.Id)
+                ) ?? currentCharacter;
+
+                // Materialize Orobas's pools in the same order as the base method, without
+                // modifying the event model's property results.
+                var pool1 = GetPrivateProperty<IEnumerable<EventOption>>(__instance, "OptionPool1").ToList();
+
+                EventOption dynamicPool1Option;
+                if (__instance.Rng.NextFloat() < 0.3333333f)
+                {
+                    dynamicPool1Option = GetPrivateProperty<EventOption>(
+                        __instance,
+                        "PrismaticGemOption"
+                    );
+                }
+                else
+                {
+                    dynamicPool1Option = GetPrivateProperty<IEnumerable<EventOption>>(
+                        __instance,
+                        "SeaGlassOptions"
+                    ).FirstOrDefault(option =>
+                        option.Relic is SeaGlass seaGlass &&
+                        seaGlass.CharacterId == seaGlassCharacter.Id
+                    ) ?? throw new InvalidOperationException(
+                        $"Orobas has no Sea Glass option for {seaGlassCharacter.Id}."
+                    );
+                }
+
+                pool1.Add(dynamicPool1Option);
+                pool1.RemoveAll(IsBlocked);
+                var firstOption = PickRequired(
+                    __instance,
+                    pool1,
+                    "Orobas option pool 1 contains no valid options."
+                );
+
+                var pool2 = GetPrivateProperty<IEnumerable<EventOption>>(__instance, "OptionPool2").ToList();
+                pool2.RemoveAll(IsBlocked);
+                var secondOption = PickRequired(
+                    __instance,
+                    pool2,
+                    "Orobas option pool 2 contains no valid options."
+                );
+
+                var pool3 = GetPrivateProperty<IEnumerable<EventOption>>(__instance, "OptionPool3").ToList();
+                pool3.RemoveAll(option => IsBlocked(option) || option.Relic is null);
+                var thirdOptionPool = pool3.Count > 0
+                    ? pool3
+                    : BuildFallbackThirdPool(pool1, pool2, firstOption, secondOption);
+                var thirdOption = PickRequired(
+                    __instance,
+                    thirdOptionPool,
+                    "Orobas contains no valid option for its third reward."
+                );
+
+                __result = new[] { firstOption, secondOption, thirdOption };
+                return false;
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Error(
+                    $"Could not filter progressive starter relics from Orobas; " +
+                    $"falling back to the base-game options. {ex}"
+                );
+                return true;
+            }
+        }
+
+        private static bool IsBlocked(EventOption option)
+        {
+            return option.Relic switch
+            {
+                ArchaicTooth => ArchipelagoClient.Settings?.ProgressiveStarterCard == true,
+                TouchOfOrobas => ArchipelagoClient.Settings?.ProgressiveStarterRelic == true,
+                _ => false,
+            };
+        }
+
+        private static bool ShouldFilterProgressiveStarters() =>
+            ArchipelagoClient.Settings?.ProgressiveStarterCard == true ||
+            ArchipelagoClient.Settings?.ProgressiveStarterRelic == true;
+
+        private static List<EventOption> BuildFallbackThirdPool(
+            IEnumerable<EventOption> pool1,
+            IEnumerable<EventOption> pool2,
+            EventOption firstOption,
+            EventOption secondOption)
+        {
+            var selectedRelicIds = new HashSet<string>();
+            if (firstOption.Relic is not null)
+                selectedRelicIds.Add(firstOption.Relic.Id.ToString());
+            if (secondOption.Relic is not null)
+                selectedRelicIds.Add(secondOption.Relic.Id.ToString());
+
+            return pool1
+                .Concat(pool2)
+                .Where(option =>
+                    option.Relic is null || !selectedRelicIds.Contains(option.Relic.Id.ToString()))
+                .GroupBy(GetOptionIdentity)
+                .Select(group => group.First())
+                .ToList();
+        }
+
+        private static string GetOptionIdentity(EventOption option) =>
+            option.Relic?.Id.ToString() ?? $"EVENT_OPTION:{option.TextKey}";
+
+        private static EventOption PickRequired(
+            Orobas instance,
+            IReadOnlyList<EventOption> pool,
+            string errorMessage)
+        {
+            if (pool.Count == 0)
+                throw new InvalidOperationException(errorMessage);
+
+            return instance.Rng.NextItem(pool)
+                ?? throw new InvalidOperationException(errorMessage);
+        }
+
+        private static T GetPrivateProperty<T>(Orobas instance, string propertyName)
+            where T : class
+        {
+            var property = AccessTools.Property(instance.GetType(), propertyName)
+                ?? throw new MissingMemberException(instance.GetType().FullName, propertyName);
+
+            return property.GetValue(instance) as T
+                ?? throw new InvalidOperationException(
+                    $"{instance.GetType().Name}.{propertyName} did not contain a {typeof(T).FullName}."
+                );
+        }
+    }
+
     [HarmonyPatch(typeof(AncientEventModel), "GenerateInitialOptionsWrapper")]
     public static class Patches_AncientRelics
     {

--- a/client/StS2AP/Patches/Patches_HookRunStart.cs
+++ b/client/StS2AP/Patches/Patches_HookRunStart.cs
@@ -11,6 +11,7 @@ using StS2AP.UI;
 using StS2AP.Utils;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using static Godot.HttpRequest;
 
 namespace StS2AP.Patches
@@ -78,6 +79,33 @@ namespace StS2AP.Patches
 
                 // Clear buffers
                 ArchipelagoClient.Progress.UsedItems.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Reconciles progressive starters after the base game has finalized starting relic effects,
+        /// but before it launches the run scene. At this point each player has a real RunState and
+        /// relic removal can pair AfterRemoved with the base game's completed AfterObtained call.
+        /// </summary>
+        [HarmonyPatch(typeof(RunManager), nameof(RunManager.FinalizeStartingRelics))]
+        public static class OnStartingRelicsFinalized
+        {
+            [HarmonyPostfix]
+            public static void Postfix(ref Task __result)
+            {
+                __result = ReconcileProgressiveStarters(__result);
+            }
+
+            private static async Task ReconcileProgressiveStarters(Task finalizeTask)
+            {
+                await finalizeTask;
+
+                var player = GameUtility.CurrentPlayer;
+                var runState = RunManager.Instance.DebugOnlyGetState();
+                if (player == null || !ReferenceEquals(player.RunState, runState))
+                    return;
+
+                await ProgressiveStarterUtility.InitializeForRun(player);
             }
         }
 

--- a/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
+++ b/client/StS2AP/UI/ArchipelagoCharTrackerUI.cs
@@ -2,6 +2,7 @@
 using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Potions;
+using MegaCrit.Sts2.Core.Models.Relics;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using StS2AP.UI.Components;
 using static StS2AP.Patches.Patches_APProgressOnCharSelect;
@@ -111,6 +112,12 @@ namespace StS2AP.UI
 
         /// <summary>Tracks the number of Progressive Smith rewards received.</summary>
         public static ItemCountLabel? ProgressiveSmithLabel { get; private set; }
+
+        /// <summary>Tracks the number of Progressive Starter Card rewards received.</summary>
+        public static ItemCountLabel? ProgressiveStarterCardLabel { get; private set; }
+
+        /// <summary>Tracks the number of Progressive Starter Relic rewards received.</summary>
+        public static ItemCountLabel? ProgressiveStarterRelicLabel { get; private set; }
 
         #endregion
 
@@ -244,6 +251,8 @@ namespace StS2AP.UI
                 GoldRewards          = null;
                 ProgressiveRestLabel = null;
                 ProgressiveSmithLabel = null;
+                ProgressiveStarterCardLabel = null;
+                ProgressiveStarterRelicLabel = null;
             }
         }
 
@@ -541,6 +550,26 @@ namespace StS2AP.UI
             // Progressive Smith Total
             ProgressiveSmithLabel = new ItemCountLabel("res://images/relics/whetstone.png", "(0 / 3)", "AP_REWARD_PROGRESSIVE_SMITH");
             AddItemRow(ProgressiveSmithLabel);
+
+            if (ArchipelagoClient.Settings.ProgressiveStarterCard)
+            {
+                ProgressiveStarterCardLabel = new ItemCountLabel(
+                    ModelDb.Relic<ArchaicTooth>().IconPath,
+                    "(0 / 2)",
+                    "AP_REWARD_PROGRESSIVE_STARTER_CARD"
+                );
+                AddItemRow(ProgressiveStarterCardLabel);
+            }
+
+            if (ArchipelagoClient.Settings.ProgressiveStarterRelic)
+            {
+                ProgressiveStarterRelicLabel = new ItemCountLabel(
+                    ModelDb.Relic<TouchOfOrobas>().IconPath,
+                    "(0 / 2)",
+                    "AP_REWARD_PROGRESSIVE_STARTER_RELIC"
+                );
+                AddItemRow(ProgressiveStarterRelicLabel);
+            }
 
             // Set initial values based on the first character from the select screen
             UpdateCharTrackerUI.UpdateCheckedLocations(character);

--- a/client/StS2AP/Utils/ProgressiveStarterUtility.cs
+++ b/client/StS2AP/Utils/ProgressiveStarterUtility.cs
@@ -130,16 +130,32 @@ namespace StS2AP.Utils
                     return;
 
                 if (ArchipelagoClient.Settings?.ProgressiveStarterCard == true)
-                    await ReconcileCardAsync(player);
+                {
+                    try
+                    {
+                        await ReconcileCardAsync(player);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogUtility.Error(
+                            $"Failed to reconcile progressive starter card for {player.Character.Id.Entry}: {ex}"
+                        );
+                    }
+                }
 
                 if (ArchipelagoClient.Settings?.ProgressiveStarterRelic == true)
-                    await ReconcileRelicAsync(player);
-            }
-            catch (Exception ex)
-            {
-                LogUtility.Error(
-                    $"Failed to reconcile progressive starters for {player.Character.Id.Entry}: {ex}"
-                );
+                {
+                    try
+                    {
+                        await ReconcileRelicAsync(player);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogUtility.Error(
+                            $"Failed to reconcile progressive starter relic for {player.Character.Id.Entry}: {ex}"
+                        );
+                    }
+                }
             }
             finally
             {

--- a/client/StS2AP/Utils/ProgressiveStarterUtility.cs
+++ b/client/StS2AP/Utils/ProgressiveStarterUtility.cs
@@ -1,0 +1,392 @@
+using Godot;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
+using StS2AP.Extensions;
+using StS2AP.Models;
+
+namespace StS2AP.Utils
+{
+    /// <summary>
+    /// Applies the two progressive starter tiers to the active run.
+    ///
+    /// The vanilla Orobas methods are deliberately the compatibility boundary: RitsuLib and
+    /// BaseLib patch those methods for compatible modded characters. If the methods do not expose
+    /// a real transformation, this utility leaves that character's starter untouched.
+    /// </summary>
+    public static class ProgressiveStarterUtility
+    {
+        private static readonly SemaphoreSlim ReconcileLock = new(1, 1);
+
+        /// <summary>
+        /// Captures supported starter identities while the vanilla starting deck and relics are
+        /// still present, then applies the tier already received from Archipelago.
+        /// </summary>
+        public static async Task InitializeForRun(Player player)
+        {
+            if (ArchipelagoClient.Settings?.ProgressiveStarterCard == true)
+                CaptureStarterCard(player);
+
+            if (ArchipelagoClient.Settings?.ProgressiveStarterRelic == true)
+                CaptureStarterRelic(player);
+
+            await ReconcileAsync(player);
+        }
+
+        /// <summary>
+        /// Incoming Archipelago items are processed off the Godot main thread. Defer all deck and
+        /// relic mutations so the game commands execute on the main thread.
+        /// </summary>
+        public static void QueueReconcileCurrentPlayer()
+        {
+            Callable.From(() =>
+            {
+                var player = GameUtility.CurrentPlayer;
+                if (player != null)
+                    TaskHelper.RunSafely(ReconcileAsync(player));
+            }).CallDeferred();
+        }
+
+        private static void CaptureStarterCard(Player player)
+        {
+            try
+            {
+                var archaicTooth = (ArchaicTooth)ModelDb.Relic<ArchaicTooth>().ToMutable();
+                var configured = archaicTooth.SetupForPlayer(player);
+                var starterCardId = archaicTooth.StarterCard?.Id;
+                var ancientCardId = archaicTooth.AncientCard?.Id;
+                if (!configured || starterCardId == null || ancientCardId == null)
+                {
+                    LogUtility.Warn(
+                        $"Progressive Starter Card is enabled, but {player.Character.Id.Entry} " +
+                        "does not expose an Archaic Tooth starter-card mapping. Leaving its deck unchanged."
+                    );
+                    return;
+                }
+
+                var progress = ArchipelagoClient.Progress;
+                progress.ProgressiveStarterCardBaseId = starterCardId.ToString();
+                progress.ProgressiveStarterCardUpgradedId = ancientCardId.ToString();
+                progress.ProgressiveStarterCardTier = ProgressiveStarterTier.Basic;
+                LogUtility.Info(
+                    $"Progressive Starter Card mapped {starterCardId} -> {ancientCardId} " +
+                    $"for {player.Character.Id.Entry}."
+                );
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn(
+                    $"Could not resolve an Archaic Tooth starter-card mapping for " +
+                    $"{player.Character.Id.Entry}; leaving its deck unchanged. {ex.Message}"
+                );
+            }
+        }
+
+        private static void CaptureStarterRelic(Player player)
+        {
+            try
+            {
+                var touchOfOrobas = (TouchOfOrobas)ModelDb.Relic<TouchOfOrobas>().ToMutable();
+                var configured = touchOfOrobas.SetupForPlayer(player);
+                var starterRelicId = touchOfOrobas.StarterRelic;
+                var upgradedRelicId = touchOfOrobas.UpgradedRelic;
+                if (!configured || starterRelicId == null || upgradedRelicId == null)
+                {
+                    LogUtility.Warn(
+                        $"Progressive Starter Relic is enabled, but {player.Character.Id.Entry} " +
+                        "does not expose a Touch of Orobas starter-relic mapping. Leaving its relics unchanged."
+                    );
+                    return;
+                }
+
+                var progress = ArchipelagoClient.Progress;
+                progress.ProgressiveStarterRelicBaseId = starterRelicId.ToString();
+                progress.ProgressiveStarterRelicUpgradedId = upgradedRelicId.ToString();
+                progress.ProgressiveStarterRelicTier = ProgressiveStarterTier.Basic;
+                LogUtility.Info(
+                    $"Progressive Starter Relic mapped {starterRelicId} -> {upgradedRelicId} " +
+                    $"for {player.Character.Id.Entry}."
+                );
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Warn(
+                    $"Could not resolve a Touch of Orobas starter-relic mapping for " +
+                    $"{player.Character.Id.Entry}; leaving its relics unchanged. {ex.Message}"
+                );
+            }
+        }
+
+        private static async Task ReconcileAsync(Player player)
+        {
+            await ReconcileLock.WaitAsync();
+            try
+            {
+                // A deferred item callback from a previous run must never mutate a new run.
+                if (!ReferenceEquals(GameUtility.CurrentPlayer, player))
+                    return;
+
+                if (ArchipelagoClient.Settings?.ProgressiveStarterCard == true)
+                    await ReconcileCardAsync(player);
+
+                if (ArchipelagoClient.Settings?.ProgressiveStarterRelic == true)
+                    await ReconcileRelicAsync(player);
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Error(
+                    $"Failed to reconcile progressive starters for {player.Character.Id.Entry}: {ex}"
+                );
+            }
+            finally
+            {
+                ReconcileLock.Release();
+            }
+        }
+
+        private static async Task ReconcileCardAsync(Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            if (progress.ProgressiveStarterCardBaseId == null ||
+                progress.ProgressiveStarterCardUpgradedId == null ||
+                progress.ProgressiveStarterCardTier == ProgressiveStarterTier.Unsupported)
+            {
+                return;
+            }
+
+            var targetTier = GetTargetTier(progress.ProgressiveStarterCards, player);
+            if (targetTier == ProgressiveStarterTier.Unsupported)
+                return;
+            var currentTier = progress.ProgressiveStarterCardTier;
+            if (targetTier == currentTier)
+                return;
+
+            // A new run is constructed with its vanilla tier-one starter before AP reconciliation.
+            // This is the only expected downward transition; received AP items only increase later.
+            if (currentTier == ProgressiveStarterTier.Basic && targetTier == ProgressiveStarterTier.None)
+            {
+                var baseCard = FindDeckCard(player, progress.ProgressiveStarterCardBaseId);
+                if (baseCard == null)
+                {
+                    LogUtility.Warn(
+                        $"Could not find progressive starter card {progress.ProgressiveStarterCardBaseId} " +
+                        "in the deck; leaving its current state unchanged."
+                    );
+                    return;
+                }
+
+                await CardPileCmd.RemoveFromDeck(baseCard, showPreview: false);
+                progress.ProgressiveStarterCardTier = ProgressiveStarterTier.None;
+                LogTierTransition("Card", player, ProgressiveStarterTier.None, progress.ProgressiveStarterCardBaseId);
+                return;
+            }
+
+            if (currentTier == ProgressiveStarterTier.None &&
+                targetTier is ProgressiveStarterTier.Basic or ProgressiveStarterTier.Upgraded)
+            {
+                var baseCanonical = FindCanonicalCard(progress.ProgressiveStarterCardBaseId);
+                if (baseCanonical == null)
+                {
+                    LogUtility.Warn(
+                        $"Could not resolve progressive starter card {progress.ProgressiveStarterCardBaseId}; " +
+                        "leaving its current state unchanged."
+                    );
+                    return;
+                }
+
+                var cardToAdd = player.RunState.CreateCard(baseCanonical, player);
+                var addResult = await CardPileCmd.Add(
+                    cardToAdd,
+                    PileType.Deck,
+                    skipVisuals: true
+                );
+                if (!addResult.success)
+                    throw new InvalidOperationException($"The game rejected starter card {cardToAdd.Id}.");
+
+                currentTier = ProgressiveStarterTier.Basic;
+                progress.ProgressiveStarterCardTier = currentTier;
+                LogTierTransition("Card", player, currentTier, cardToAdd.Id.ToString());
+            }
+
+            if (currentTier == ProgressiveStarterTier.Basic && targetTier == ProgressiveStarterTier.Upgraded)
+            {
+                // Compatibility test point: grant the actual Ancient instead of reproducing its
+                // transformation. This delegates upgrade/enchantment preservation, visual feedback,
+                // and BaseLib/RitsuLib patches to Archaic Tooth's normal obtain behavior.
+                var archaicTooth = (ArchaicTooth)ModelDb.Relic<ArchaicTooth>().ToMutable();
+                if (!archaicTooth.SetupForPlayer(player))
+                {
+                    throw new InvalidOperationException(
+                        "Archaic Tooth could not configure itself for the current starter card."
+                    );
+                }
+                await RelicCmd.Obtain(archaicTooth, player);
+
+                if (FindOwnedRelic(player, archaicTooth.Id.ToString()) == null)
+                {
+                    throw new InvalidOperationException(
+                        "The game did not add Archaic Tooth after receiving the upgraded starter-card tier."
+                    );
+                }
+
+                progress.ProgressiveStarterCardTier = ProgressiveStarterTier.Upgraded;
+                if (FindDeckCard(player, progress.ProgressiveStarterCardUpgradedId) == null)
+                {
+                    LogUtility.Warn(
+                        $"Archaic Tooth was obtained, but expected transformed starter card " +
+                        $"{progress.ProgressiveStarterCardUpgradedId} was not found."
+                    );
+                }
+                LogTierTransition(
+                    "Card",
+                    player,
+                    ProgressiveStarterTier.Upgraded,
+                    progress.ProgressiveStarterCardUpgradedId
+                );
+            }
+        }
+
+        private static async Task ReconcileRelicAsync(Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            if (progress.ProgressiveStarterRelicBaseId == null ||
+                progress.ProgressiveStarterRelicUpgradedId == null ||
+                progress.ProgressiveStarterRelicTier == ProgressiveStarterTier.Unsupported)
+            {
+                return;
+            }
+
+            var targetTier = GetTargetTier(progress.ProgressiveStarterRelics, player);
+            if (targetTier == ProgressiveStarterTier.Unsupported)
+                return;
+            var currentTier = progress.ProgressiveStarterRelicTier;
+            if (targetTier == currentTier)
+                return;
+
+            // As with cards, the run initially contains the vanilla tier-one relic. Removing it for
+            // target tier zero is initialization, not a reversal of received AP progression.
+            if (currentTier == ProgressiveStarterTier.Basic && targetTier == ProgressiveStarterTier.None)
+            {
+                var baseRelic = FindOwnedRelic(player, progress.ProgressiveStarterRelicBaseId);
+                if (baseRelic == null)
+                {
+                    LogUtility.Warn(
+                        $"Could not find progressive starter relic {progress.ProgressiveStarterRelicBaseId}; " +
+                        "leaving its current state unchanged."
+                    );
+                    return;
+                }
+
+                await RelicCmd.Remove(baseRelic);
+                progress.ProgressiveStarterRelicTier = ProgressiveStarterTier.None;
+                LogTierTransition("Relic", player, ProgressiveStarterTier.None, progress.ProgressiveStarterRelicBaseId);
+                return;
+            }
+
+            if (currentTier == ProgressiveStarterTier.None &&
+                targetTier is ProgressiveStarterTier.Basic or ProgressiveStarterTier.Upgraded)
+            {
+                var relicCanonical = FindCanonicalRelic(progress.ProgressiveStarterRelicBaseId);
+                if (relicCanonical == null)
+                {
+                    LogUtility.Warn(
+                        $"Could not resolve progressive starter relic {progress.ProgressiveStarterRelicBaseId}; " +
+                        "leaving its current state unchanged."
+                    );
+                    return;
+                }
+
+                await RelicCmd.Obtain(relicCanonical.ToMutable(), player);
+                currentTier = ProgressiveStarterTier.Basic;
+                progress.ProgressiveStarterRelicTier = currentTier;
+                LogTierTransition("Relic", player, currentTier, relicCanonical.Id.ToString());
+            }
+
+            if (currentTier == ProgressiveStarterTier.Basic && targetTier == ProgressiveStarterTier.Upgraded)
+            {
+                // Compatibility test point: grant Touch itself so its normal obtain behavior owns
+                // the replacement and any BaseLib/RitsuLib compatibility patches. If a modded
+                // starter behaves unexpectedly, this is the isolated call to disable while testing.
+                var touchOfOrobas = (TouchOfOrobas)ModelDb.Relic<TouchOfOrobas>().ToMutable();
+                if (!touchOfOrobas.SetupForPlayer(player))
+                {
+                    throw new InvalidOperationException(
+                        "Touch of Orobas could not configure itself for the current starter relic."
+                    );
+                }
+                await RelicCmd.Obtain(touchOfOrobas, player);
+
+                if (FindOwnedRelic(player, touchOfOrobas.Id.ToString()) == null)
+                {
+                    throw new InvalidOperationException(
+                        "The game did not add Touch of Orobas after receiving the upgraded starter-relic tier."
+                    );
+                }
+
+                progress.ProgressiveStarterRelicTier = ProgressiveStarterTier.Upgraded;
+                if (FindOwnedRelic(player, progress.ProgressiveStarterRelicUpgradedId) == null)
+                {
+                    LogUtility.Warn(
+                        $"Touch of Orobas was obtained, but expected upgraded starter relic " +
+                        $"{progress.ProgressiveStarterRelicUpgradedId} was not found."
+                    );
+                }
+                LogTierTransition(
+                    "Relic",
+                    player,
+                    ProgressiveStarterTier.Upgraded,
+                    progress.ProgressiveStarterRelicUpgradedId
+                );
+            }
+        }
+
+        private static void LogTierTransition(
+            string kind,
+            Player player,
+            ProgressiveStarterTier tier,
+            string modelId)
+        {
+            LogUtility.Success(
+                $"Progressive Starter {kind} applied tier {tier} ({(int)tier}) for " +
+                $"{player.Character.Id.Entry} (model: {modelId})."
+            );
+        }
+
+        private static ProgressiveStarterTier GetTargetTier(
+            Dictionary<long, int> received,
+            Player player)
+        {
+            var offset = player.Character.GetCharacterOffset();
+            if (offset == null)
+            {
+                LogUtility.Warn(
+                    $"Cannot reconcile progressive starters for unconfigured character " +
+                    $"{player.Character.Id}; leaving its starting inventory unchanged."
+                );
+                return ProgressiveStarterTier.Unsupported;
+            }
+
+            received.TryGetValue(offset.Value, out var count);
+            return (ProgressiveStarterTier)Math.Clamp(count, 0, 2);
+        }
+
+        private static CardModel? FindDeckCard(Player player, string idEntry) =>
+            player.Deck.Cards.FirstOrDefault(card =>
+                string.Equals(card.Id.ToString(), idEntry, StringComparison.OrdinalIgnoreCase));
+
+        private static RelicModel? FindOwnedRelic(Player player, string idEntry) =>
+            player.Relics.FirstOrDefault(relic =>
+                string.Equals(relic.Id.ToString(), idEntry, StringComparison.OrdinalIgnoreCase));
+
+        private static CardModel? FindCanonicalCard(string idEntry) =>
+            ModelDb.AllCards.FirstOrDefault(card =>
+                string.Equals(card.Id.ToString(), idEntry, StringComparison.OrdinalIgnoreCase));
+
+        private static RelicModel? FindCanonicalRelic(string idEntry) =>
+            ModelDb.AllRelics.FirstOrDefault(relic =>
+                string.Equals(relic.Id.ToString(), idEntry, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/client/StS2AP/godot/Archipelago/localization/eng/static_hover_tips.json
+++ b/client/StS2AP/godot/Archipelago/localization/eng/static_hover_tips.json
@@ -36,5 +36,9 @@
   "AP_REWARD_PROGRESSIVE_REST.title": "Progressive Rests",
   "AP_REWARD_PROGRESSIVE_REST.description": "The number of Progressive Rest rewards received for this character. The number of these represents the highest Act you can Heal at.",
   "AP_REWARD_PROGRESSIVE_SMITH.title": "Progressive Smiths",
-  "AP_REWARD_PROGRESSIVE_SMITH.description": "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at."
+  "AP_REWARD_PROGRESSIVE_SMITH.description": "The number of Progressive Smith rewards received for this character. The number of these represents the highest Act you can Upgrade at.",
+  "AP_REWARD_PROGRESSIVE_STARTER_CARD.title": "Progressive Starter Card",
+  "AP_REWARD_PROGRESSIVE_STARTER_CARD.description": "The number of Progressive Starter Card items received for this character. For supported characters: none, the normal starter card, then its Archaic Tooth transformation.",
+  "AP_REWARD_PROGRESSIVE_STARTER_RELIC.title": "Progressive Starter Relic",
+  "AP_REWARD_PROGRESSIVE_STARTER_RELIC.description": "The number of Progressive Starter Relic items received for this character. For supported characters: none, the normal starter relic, then its Touch of Orobas refinement."
 }

--- a/world/spire2/items.py
+++ b/world/spire2/items.py
@@ -24,6 +24,8 @@ class ItemType(Enum):
     CHAR_UNLOCK = auto()
     POTION = auto()
     ASCENSION_DOWN = auto()
+    PROGRESSIVE_STARTER_CARD = auto()
+    PROGRESSIVE_STARTER_RELIC = auto()
     # TRAP = auto()
     CAW_CAW = auto()
     BUFF = auto()
@@ -63,6 +65,8 @@ base_item_table: Dict[str, ItemData] = {
     'Progressive Shop Remove': ItemData(13, ItemType.SHOP_REMOVE, ItemClassification.progression_deprioritized),
     'Unlock': ItemData(14, ItemType.CHAR_UNLOCK, ItemClassification.progression),
     'Potion': ItemData(18, ItemType.POTION, ItemClassification.useful),
+    'Progressive Starter Card': ItemData(29, ItemType.PROGRESSIVE_STARTER_CARD, ItemClassification.progression),
+    'Progressive Starter Relic': ItemData(30, ItemType.PROGRESSIVE_STARTER_RELIC, ItemClassification.progression),
 
     # Event Items
     'Victory': ItemData(None, ItemType.EVENT, ItemClassification.progression, True, True),

--- a/world/spire2/options.py
+++ b/world/spire2/options.py
@@ -160,6 +160,44 @@ class RelicChoiceCount(Range):
     default = 1
 
 
+class ProgressiveStarterCard(Toggle):
+    """Globally enables progressive special starter cards for every configured character.
+
+    Requires Include Floor Checks. Each character gets two Progressive Starter Card items, which
+    replace two floor-check filler items. With none received, the character
+    starts without the special starter card that Archaic Tooth would transform (Bash, Neutralize,
+    Dualcast, Unleash, Falling Star, or a compatible modded equivalent). The first item restores
+    the normal card and the second grants Archaic Tooth so its normal effect performs the
+    transformation. Archaic Tooth is unavailable from Orobas while this option is enabled.
+
+    Characters without an Archaic Tooth transformation are left unchanged, although their two
+    Progressive Starter Card items are still present in the multiworld.
+
+    WARNING: This can make the early game significantly harder for some characters. Logic does not
+    account for the missing or upgraded starter card."""
+    display_name = "Progressive Starter Card"
+    default = 0
+
+
+class ProgressiveStarterRelic(Toggle):
+    """Globally enables progressive starter relics for every configured character.
+
+    Requires Include Floor Checks. Each character gets two Progressive Starter Relic items, which
+    replace two floor-check filler items. With none received, the character
+    starts without the starter relic that Touch of Orobas would refine (such as Burning Blood, or a
+    compatible modded equivalent). The first item restores the normal relic and the second grants
+    Touch of Orobas so its normal effect performs the refinement. Touch of Orobas is unavailable
+    from Orobas while this option is enabled.
+
+    Characters without a Touch of Orobas refinement are left unchanged, although their two
+    Progressive Starter Relic items are still present in the multiworld.
+
+    WARNING: This can make the early game significantly harder for characters whose starting relic
+    is central to their early power. Logic does not account for the missing or upgraded starter relic."""
+    display_name = "Progressive Starter Relic"
+    default = 0
+
+
 class IncludeFloorChecks(Toggle):
     """Whether to include reaching new floors as a location. Adds various fillers as items."""
     display_name = "Include Floor Checks"
@@ -579,6 +617,8 @@ class Spire2Options(PerGameCommonOptions):
     # trap_chance: TrapChance
     # trap_weights: TrapWeights
     neow_sanity: NeowSanity
+    progressive_starter_card: ProgressiveStarterCard
+    progressive_starter_relic: ProgressiveStarterRelic
     campfire_sanity: CampfireSanity
     gold_sanity: GoldSanity
     potion_sanity: PotionSanity

--- a/world/spire2/test/option_tests.py
+++ b/world/spire2/test/option_tests.py
@@ -143,3 +143,52 @@ class TestBasicModdedChars(Spire2TestBase):
         },
         "modded_characters": ["WATCHER-WATCHER"]
     }
+
+
+class TestProgressiveStartersDisabled(Spire2TestBase):
+    def test_no_progressive_starters(self):
+        names = [item.name for item in self.world.multiworld.itempool]
+        self.assertNotIn("Ironclad Progressive Starter Card", names)
+        self.assertNotIn("Ironclad Progressive Starter Relic", names)
+
+
+class TestProgressiveStartersEnabled(Spire2TestBase):
+    options = {
+        "characters": ["ironclad", "silent"],
+        "progressive_starter_card": True,
+        "progressive_starter_relic": True,
+    }
+
+    def test_two_progressive_starters_per_character(self):
+        names = [item.name for item in self.world.multiworld.itempool]
+        for character in ("Ironclad", "Silent"):
+            self.assertEqual(names.count(f"{character} Progressive Starter Card"), 2)
+            self.assertEqual(names.count(f"{character} Progressive Starter Relic"), 2)
+
+    def test_normal_reward_counts_are_preserved(self):
+        names = [item.name for item in self.world.multiworld.itempool]
+        for character in ("Ironclad", "Silent"):
+            self.assertEqual(names.count(f"{character} Card Reward"), 10)
+            self.assertEqual(names.count(f"{character} Relic"), 10)
+
+    def test_progressive_starters_are_sent_to_the_client(self):
+        slot_data = self.world.fill_slot_data()
+        self.assertEqual(slot_data["progressive_starter_card"], 1)
+        self.assertEqual(slot_data["progressive_starter_relic"], 1)
+
+
+class TestProgressiveStartersRequireFloorChecks(Spire2TestBase):
+    options = {
+        "progressive_starter_card": True,
+        "progressive_starter_relic": True,
+        "include_floor_checks": False,
+    }
+
+    def test_progressive_starters_are_disabled(self):
+        names = [item.name for item in self.world.multiworld.itempool]
+        self.assertNotIn("Ironclad Progressive Starter Card", names)
+        self.assertNotIn("Ironclad Progressive Starter Relic", names)
+
+        slot_data = self.world.fill_slot_data()
+        self.assertEqual(slot_data["progressive_starter_card"], 0)
+        self.assertEqual(slot_data["progressive_starter_relic"], 0)

--- a/world/spire2/web_world.py
+++ b/world/spire2/web_world.py
@@ -6,7 +6,7 @@ from .options import (
     LockCharacters, UnlockedCharacter, Ascension,
     IncludeFloorChecks, CampfireSanity, GoldSanity, PotionSanity,
     AncientRelicLocation, AncientRelicPool, RelicChoiceCount,
-    CardReward,
+    CardReward, ProgressiveStarterCard, ProgressiveStarterRelic,
     OneGoldFillerWeight, FiveGoldFillerWeight,
     FreeAttackFillerWeight, FreePowerFillerWeight, FreeSkillFillerWeight,
     DexterityFillerWeight, StrengthFillerWeight, PlatingFillerWeight,
@@ -52,6 +52,10 @@ class SlayTheSpire2Web(WebWorld):
             DeathLink,
             EnableDeathFragments,
             DeathLinkDamagePercent,
+        ]),
+        OptionGroup("Progressive Starters", [
+            ProgressiveStarterCard,
+            ProgressiveStarterRelic,
         ]),
         OptionGroup("Filler Items", [
             OneGoldFillerWeight,

--- a/world/spire2/world.py
+++ b/world/spire2/world.py
@@ -69,6 +69,11 @@ class SlayTheSpire2World(World):
 
         if not self.characters:
             raise OptionError("At least one character must be configured")
+        if self.options.include_floor_checks.value == 0:
+            # Progressive starter items replace floor-check filler. Without those locations there
+            # is no filler budget for them, so normalize both global toggles to disabled.
+            self.options.progressive_starter_card.value = 0
+            self.options.progressive_starter_relic.value = 0
         names = set()
         for config in self.characters:
             # self.logger.info("StS: Got character configuration" + str(config))
@@ -541,6 +546,10 @@ class SlayTheSpire2World(World):
                     amount = 2 if self.options.neow_sanity.value == 0 else 3
                 elif ItemType.RELIC == data.type:
                     amount = 10
+                elif ItemType.PROGRESSIVE_STARTER_CARD == data.type:
+                    amount = 2 if self.options.progressive_starter_card.value else 0
+                elif ItemType.PROGRESSIVE_STARTER_RELIC == data.type:
+                    amount = 2 if self.options.progressive_starter_relic.value else 0
                 elif ItemType.CAMPFIRE == data.type:
                     if self.options.campfire_sanity.value != 0:
                         amount = 3
@@ -587,7 +596,11 @@ class SlayTheSpire2World(World):
                     remaining_checks += 1
 
                 # Generate filler items for floor checks using the weighted filler system
-                filler_num = remaining_checks
+                progressive_starter_items = (
+                    (2 if self.options.progressive_starter_card.value else 0) +
+                    (2 if self.options.progressive_starter_relic.value else 0)
+                )
+                filler_num = remaining_checks - progressive_starter_items
                 
                 for _ in range(filler_num):
                     filler_item_name = self.get_filler_item(character=config.name)
@@ -679,6 +692,8 @@ class SlayTheSpire2World(World):
             "potion_sanity",
             "gold_sanity",
             "campfire_sanity",
+            "progressive_starter_card",
+            "progressive_starter_relic",
             "death_link",
             "enable_death_fragments",
             "death_link_damage_percent",
@@ -719,6 +734,11 @@ class SlayTheSpire2World(World):
         self.options.ancient_relic_pool.value = slot_data['ancient_relic_pool']
         self.options.relic_choice_count.value = slot_data['relic_choice_count']
         self.options.campfire_sanity.value = slot_data['campfire_sanity']
+        self.options.progressive_starter_card.value = slot_data['progressive_starter_card']
+        self.options.progressive_starter_relic.value = slot_data['progressive_starter_relic']
+        if self.options.include_floor_checks.value == 0:
+            self.options.progressive_starter_card.value = 0
+            self.options.progressive_starter_relic.value = 0
         self.options.shop_sanity.value = slot_data['shop_sanity']
         self.options.gold_sanity.value = slot_data['gold_sanity']
         self.options.potion_sanity.value = slot_data['potion_sanity']


### PR DESCRIPTION
This should work with modded characters as all modded characters SHOULD support the Orobas relics (otherwise they'll crash or get a circlet, I believe we won't crash but you never know).

Works on main branch and beta branch.

Prevents getting the Orobas Relics if you turn these on and due to both 'Touch of Orobas' and 'Archaic Tooth' occupying Pool 3, some pool adjustments are neeed for Orobas specifically. 

The upgrades are done by granting the Orobas relics directly.

I forgot to do logic for these but i wonder if it's actually ok. Gives people an additional challenge (more challenging start) but stronger end. Maybe a lot of play testing will be needed to truly see how ok this is.