### PR TITLE
Adds support for Rewarding Elites by implementing 'Progressive Relics'

### DIFF
--- a/client/StS2AP/ArchipelagoClient.cs
+++ b/client/StS2AP/ArchipelagoClient.cs
@@ -9,6 +9,7 @@ using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using Newtonsoft.Json.Linq;
 using StS2AP.Data;
+using StS2AP.Extensions;
 using StS2AP.Models;
 using StS2AP.UI;
 using StS2AP.Utils;
@@ -865,6 +866,42 @@ namespace StS2AP
 
                         break;
                     }
+                case APItem.Relic:
+                {
+                    // Save loading replays the whole item list, then reconciles once at the end.
+                    if (!refresh)
+                    {
+                        Progress.AllReceivedItems.Add(new IndexedItemInfo(item, index));
+                        return;
+                    }
+
+                    // Receipt storage, RelicFactory, and the AP reward UI share run state, so keep
+                    // the whole live-delivery path on Godot's main thread.
+                    Callable.From(() =>
+                    {
+                        // Keep every receipt. Other characters and out-of-run deliveries may
+                        // matter when their run starts or a checkpoint is loaded.
+                        Progress.AllReceivedItems.Add(new IndexedItemInfo(item, index));
+
+                        var player = GameUtility.CurrentPlayer;
+                        var characterOffset = player?.Character.GetCharacterOffset();
+                        if (player == null
+                            || !characterOffset.HasValue
+                            || item.GetCharacterOffset() != characterOffset.Value)
+                        {
+                            return;
+                        }
+
+                        // A receipt arriving after its Elite/chest reward belongs in the AP menu.
+                        // Reconcile all pairs so checkpoint loads do not depend on callback order.
+                        RelicRewardUtility.ReconcileBankedRewards(player);
+                        if (ArchipelagoRewardUI.IsOpen)
+                            ArchipelagoRewardUI.ShowRewards();
+                        else
+                            ArchipelagoTopBarUI.RefreshCount();
+                    }).CallDeferred();
+                    return;
+                }
                 case APItem.SwarmingElites:
                 case APItem.WearyTraveler:
                 case APItem.Poverty:
@@ -1070,7 +1107,10 @@ namespace StS2AP
 
             settings.AncientRelicLocation = (AncientRelicLocation)Convert.ToInt32(slotData["ancient_relic_location"]);
             settings.AncientRelicPool = (AncientRelicPoolMode)Convert.ToInt32(slotData["ancient_relic_pool"]);
-            settings.RelicChoiceCount = Convert.ToInt32(slotData["relic_choice_count"]);
+            // These keys are one APWorld/client contract. Missing values should reject the slot
+            // instead of silently changing the run's reward rules.
+            settings.RelicRewardsAvailableAnytime = Convert.ToInt32(slotData["relic_rewards_available_anytime"]);
+            settings.ReleaseOnVictory = Convert.ToBoolean(slotData["release_on_victory"]);
 
             if (slotData.ContainsKey("campfire_sanity"))
                 settings.CampfireSanity = Convert.ToInt32(slotData["campfire_sanity"]) != 0;

--- a/client/StS2AP/ModSettingsRegistration.cs
+++ b/client/StS2AP/ModSettingsRegistration.cs
@@ -28,6 +28,10 @@ public static class ModSettingsRegistration
     private const string DeathLink_FragmentsOnId = "enable_death_fragments";
     private const string DeathLink_DamageId = "deathlink_damage";
 
+    // Relic rewards
+    private const string RelicRewards_OverrideId = "override_relic_rewards_available_anytime";
+    private const string RelicRewards_AvailableAnytimeId = "relic_rewards_available_anytime";
+
     #endregion
 
     #region Handle Hotkeys
@@ -105,6 +109,7 @@ public static class ModSettingsRegistration
                     .AddSection("charnames", ConfigureModdedCharactersSection)
                     .AddSection("keybinds", ConfigureKeybindsSection)
                     .AddSection("notifications", ConfigureNotificationsSection)
+                    .AddSection("relic_rewards", ConfigureRelicRewardsSection)
                     .AddSection("deathlink", ConfigureDeathLinkSection)
         );
         RegisterHotkeys();
@@ -302,6 +307,67 @@ public static class ModSettingsRegistration
             .WithEntryEnabledWhen(DeathLink_DamageId, IsDeathLinkOverriden);
     }
 
+    private static void ConfigureRelicRewardsSection(ModSettingsSectionBuilder section)
+    {
+        section
+            .WithTitle(ModSettingsText.Literal("Relic Rewards"))
+            .WithDescription(
+                ModSettingsText.Literal("Configure Relic availability for future runs.")
+            )
+            .WithMenuCapabilities(ModSettingsMenuCapabilities.None)
+            .AddToggle(
+                RelicRewards_OverrideId,
+                ModSettingsText.Literal("Override AP Relic Availability"),
+                CreateBinding(
+                    static settings => settings.OverrideRelicRewardsAvailableAnytime,
+                    static (settings, value) =>
+                    {
+                        // Start an override from the slot's value instead of a stale local value.
+                        if (value && !settings.OverrideRelicRewardsAvailableAnytime)
+                        {
+                            settings.RelicRewardsAvailableAnytime =
+                                ArchipelagoClient.Settings?.RelicRewardsAvailableAnytime
+                                ?? settings.RelicRewardsAvailableAnytime;
+                        }
+
+                        settings.OverrideRelicRewardsAvailableAnytime = value;
+                    }
+                ),
+                ModSettingsText.Literal(
+                    "Use a local value instead of the one supplied by the Archipelago slot."
+                )
+            )
+            .ConfigureEntryMenu(
+                RelicRewards_OverrideId,
+                ModSettingsMenuCapabilities.None
+            )
+            .AddIntSlider(
+                RelicRewards_AvailableAnytimeId,
+                ModSettingsText.Literal("Relics Available Anytime"),
+                CreateBinding(
+                    static settings => settings.OverrideRelicRewardsAvailableAnytime
+                        ? settings.RelicRewardsAvailableAnytime
+                        : ArchipelagoClient.Settings?.RelicRewardsAvailableAnytime
+                            ?? settings.RelicRewardsAvailableAnytime,
+                    static (settings, value) => settings.RelicRewardsAvailableAnytime = value
+                ),
+                minValue: 0,
+                maxValue: 10,
+                step: 1,
+                description: ModSettingsText.Literal(
+                    "Overrides the AP slot setting for new runs. Does not affect the current run."
+                )
+            )
+            .ConfigureEntryMenu(
+                RelicRewards_AvailableAnytimeId,
+                ModSettingsMenuCapabilities.None
+            )
+            .WithEntryEnabledWhen(
+                RelicRewards_AvailableAnytimeId,
+                IsRelicRewardsOverrideEnabled
+            );
+    }
+
     #endregion
 
     #region Helper Functions
@@ -316,6 +382,12 @@ public static class ModSettingsRegistration
         var store = RitsuLibFramework.GetDataStore(ModEntry.ModId);
         var settings = store.Get<ClientSettings>("apsettings");
         return settings.OverrideDeathLinkOptions;
+    }
+
+    private static bool IsRelicRewardsOverrideEnabled()
+    {
+        var store = RitsuLibFramework.GetDataStore(ModEntry.ModId);
+        return store.Get<ClientSettings>("apsettings").OverrideRelicRewardsAvailableAnytime;
     }
 
     /// <summary>

--- a/client/StS2AP/Models/ArchipelagoProgress.cs
+++ b/client/StS2AP/Models/ArchipelagoProgress.cs
@@ -87,10 +87,22 @@ namespace StS2AP.Models
         public int RareCardRewardsAttempted { get; set; } = 0;
 
         /// <summary>
-        /// Keeps track of the number of times the game has tried to provide a Relic Reward.
-        /// Used to keep track of when to replace a Relic Reward with an AP Location.
+        /// Eligible Elite, chest, and Black Star rewards encountered this run. Attempts after ten
+        /// are still counted so the caller knows they must stay fully vanilla.
         /// </summary>
         public int RelicRewardsAttempted { get; set; } = 0;
+
+        /// <summary>
+        /// Earned relic rewards not yet paired with a received Relic item. A bank is spent when
+        /// the receipt is committed to either a native reward or a saved AP-menu assignment.
+        /// </summary>
+        public int BankedRelicRewards { get; set; } = 0;
+
+        /// <summary>
+        /// Run-start snapshot of the effective anytime setting. Changing local settings cannot
+        /// move receipts between anytime and reward-required while a run is in progress.
+        /// </summary>
+        public int RelicRewardsAvailableAnytimeForRun { get; set; } = 2;
 
         /// <summary>
         /// Keeps track of the number of times the game has tried to provide a Gold Reward.
@@ -113,7 +125,8 @@ namespace StS2AP.Models
 
         /// <summary>
         /// Maps an Archipelago Relic item's index to the choices pre-pulled from the RelicFactory for it.
-        /// This ensures that opening/closing or saving/loading the reward screen always shows the same choices.
+        /// Only AP-menu rewards use this; native Elite, chest, and Black Star rewards never do.
+        /// This ensures that reopening or loading the AP menu shows the same choice.
         /// Cleared on each new run via <see cref="ResetTrackers"/>.
         /// </summary>
         public Dictionary<int, List<RelicModel>> RelicChoiceAssignments { get; set; } = new Dictionary<int, List<RelicModel>>();
@@ -145,7 +158,7 @@ namespace StS2AP.Models
         /// </summary>
         /// <param name="index">The index of the specific item sent from the Multiworld.</param>
         /// <param name="player">The current player, needed by RelicFactory.</param>
-        /// <param name="choiceCount">The configured number of relics to offer.</param>
+        /// <param name="choiceCount">The number of relics to persist for this item.</param>
         /// <returns>The assigned relic choices, or an empty list if no player is provided or the factory fails.</returns>
         public IReadOnlyList<RelicModel> GetOrAssignRelicChoices(int index, Player player, int choiceCount)
         {
@@ -317,6 +330,8 @@ namespace StS2AP.Models
             RareCardRewardsAttempted = 0;
             BossRewardsDistributed = 0;
             RelicRewardsAttempted = 0;
+            BankedRelicRewards = 0;
+            RelicRewardsAvailableAnytimeForRun = RelicRewardUtility.EffectiveAvailableAnytime;
             GoldRewardsAttempted = 0;
             PotionRewardsAttempted = 0;
             CampfiresChecked.Clear();
@@ -355,7 +370,23 @@ namespace StS2AP.Models
         /// The number of items we've received from the multiworld that we haven't used yet. 
         /// This is what gets displayed in the top bar UI.
         /// </summary>
-        public int UnusedItemCount => AllReceivedItems.Where(i => i.Item.GetCharacterOffset() == GameUtility.CurrentConfig?.CharOffset && !i.Item.ItemDisplayName.Contains("Progressive") && !i.Item.ItemName.Contains("Progressive")).Count() - UsedItems.Count;
+        public int UnusedItemCount
+        {
+            get
+            {
+                var player = GameUtility.CurrentPlayer;
+                return AllReceivedItems.Count(item =>
+                    item.Item.GetCharacterOffset() == GameUtility.CurrentCharacterID
+                    && !item.Item.ItemDisplayName.Contains("Progressive")
+                    && !item.Item.ItemName.Contains("Progressive")
+                    && !UsedItems.Contains(item.Index)
+                    && (
+                        item.Item.GetCharacterSpecificItemID() != APItem.Relic
+                        || player != null && RelicRewardUtility.IsAvailableInRewardMenu(item, player)
+                    )
+                );
+            }
+        }
 
         #endregion
 
@@ -584,6 +615,8 @@ namespace StS2AP.Models
                 CardRewardsAttempted = CardRewardsAttempted,
                 RareCardRewardsAttempted = RareCardRewardsAttempted,
                 RelicRewardsAttempted = RelicRewardsAttempted,
+                BankedRelicRewards = BankedRelicRewards,
+                RelicRewardsAvailableAnytimeForRun = RelicRewardsAvailableAnytimeForRun,
                 GoldRewardsAttempted = GoldRewardsAttempted,
                 PotionRewardsAttempted = PotionRewardsAttempted,
                 BossRewardsDistributed = BossRewardsDistributed,
@@ -623,6 +656,8 @@ namespace StS2AP.Models
                 CardRewardsAttempted = saveData.CardRewardsAttempted,
                 RareCardRewardsAttempted = saveData.RareCardRewardsAttempted,
                 RelicRewardsAttempted = saveData.RelicRewardsAttempted,
+                BankedRelicRewards = saveData.BankedRelicRewards,
+                RelicRewardsAvailableAnytimeForRun = saveData.RelicRewardsAvailableAnytimeForRun,
                 GoldRewardsAttempted = saveData.GoldRewardsAttempted,
                 PotionRewardsAttempted = saveData.PotionRewardsAttempted,
                 BossRewardsDistributed = saveData.BossRewardsDistributed,

--- a/client/StS2AP/Models/ArchipelagoProgress.cs
+++ b/client/StS2AP/Models/ArchipelagoProgress.cs
@@ -88,7 +88,7 @@ namespace StS2AP.Models
 
         /// <summary>
         /// Eligible Elite, chest, and Black Star rewards encountered this run. Attempts after ten
-        /// are still counted so the caller knows they must stay fully vanilla.
+        /// are still counted so we can give 'natural relics'.
         /// </summary>
         public int RelicRewardsAttempted { get; set; } = 0;
 

--- a/client/StS2AP/Models/ArchipelagoSettings.cs
+++ b/client/StS2AP/Models/ArchipelagoSettings.cs
@@ -80,10 +80,12 @@ namespace StS2AP.Models
         public AncientRelicPoolMode AncientRelicPool { get; set; } = AncientRelicPoolMode.Balanced;
 
         /// <summary>
-        /// Number of relics offered when claiming a Relic received from Archipelago.
-        /// This does not affect relic rewards created by the base game or other mods.
+        /// Number of Relic receipts that do not need an earned Elite, chest, or Black Star reward.
         /// </summary>
-        public int RelicChoiceCount { get; set; } = 1;
+        public int RelicRewardsAvailableAnytime { get; set; } = 2;
+
+        /// <summary>Whether a victory releases the winning character's remaining checks.</summary>
+        public bool ReleaseOnVictory { get; set; } = true;
 
         public bool CampfireSanity { get; set; }
         public bool GoldSanity { get; set; }

--- a/client/StS2AP/Models/ClientSettings.cs
+++ b/client/StS2AP/Models/ClientSettings.cs
@@ -58,6 +58,18 @@ namespace StS2AP.Models
 
         #endregion
 
+        #region Relic Rewards
+
+        /// <summary>Whether the local anytime value replaces the AP slot setting.</summary>
+        public bool OverrideRelicRewardsAvailableAnytime { get; set; } = false;
+
+        /// <summary>
+        /// Local anytime value. It is only read when the override is enabled and only affects new runs.
+        /// </summary>
+        public int RelicRewardsAvailableAnytime { get; set; } = 2;
+
+        #endregion
+
         #region Key/Button Bindings
 
         /// <summary>

--- a/client/StS2AP/Models/RelicCoupons.cs
+++ b/client/StS2AP/Models/RelicCoupons.cs
@@ -1,0 +1,124 @@
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Entities.Relics;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.RelicPools;
+using MegaCrit.Sts2.Core.Runs;
+using StS2AP.Utils;
+using STS2RitsuLib.Interop.AutoRegistration;
+using STS2RitsuLib.Scaffolding.Content;
+
+namespace StS2AP.Models;
+
+/// <summary>
+/// Permanent AP-run indicator for earned natural relic rewards that have not yet been paired
+/// with a received AP Relic item. The authoritative value remains on ArchipelagoProgress.
+/// </summary>
+[RegisterRelic(typeof(SharedRelicPool))]
+public sealed class RelicCoupons : ModRelicTemplate
+{
+    private const string CouponIconPath = "res://images/APIcon.png";
+    private int? _activationDisplayAmount;
+    private int _activationSequence;
+
+    public override RelicRarity Rarity => RelicRarity.Starter;
+
+    public override bool ShowCounter => true;
+
+    public override int DisplayAmount =>
+        _activationDisplayAmount ?? ArchipelagoClient.Progress.BankedRelicRewards;
+
+    public override bool ShouldReceiveCombatHooks => false;
+
+    public override RelicAssetProfile AssetProfile { get; } = new(
+        IconPath: CouponIconPath,
+        IconOutlinePath: CouponIconPath,
+        BigIconPath: CouponIconPath
+    );
+
+    // This relic is granted explicitly to AP players and must never enter a natural reward pool.
+    public override bool IsAllowed(IRunState runState) => false;
+
+    /// <summary>
+    /// Adds the counter as starting-inventory state. Direct inventory insertion is intentional at
+    /// this lifecycle boundary: RelicCmd.Obtain expects a fully initialized run and would create a
+    /// reward-history entry and acquisition animation for what is effectively a starting relic.
+    /// </summary>
+    public static void EnsureOwnedBy(Player player, bool silent = false)
+    {
+        if (!ArchipelagoClient.IsConnected || player.GetRelic<RelicCoupons>() != null)
+            return;
+
+        try
+        {
+            var relic = ModelDb.Relic<RelicCoupons>().ToMutable();
+            relic.FloorAddedToDeck = 1;
+            player.AddRelicInternal(relic, silent: silent);
+            LogUtility.Info("Added the Relic Coupons counter to the AP run");
+        }
+        catch (Exception ex)
+        {
+            // The counter is presentation-only; coupon earning and redemption must remain usable.
+            LogUtility.Warn($"Could not add the Relic Coupons counter: {ex.Message}");
+        }
+    }
+
+    /// <summary>Notifies the native relic inventory after the authoritative coupon value changes.</summary>
+    public static void RefreshCounter(Player? player = null)
+    {
+        try
+        {
+            (player ?? GameUtility.CurrentPlayer)
+                ?.GetRelic<RelicCoupons>()
+                ?.InvokeCouponCountChanged();
+        }
+        catch (Exception ex)
+        {
+            // Updating the number is best-effort and must not affect coupon ownership semantics.
+            LogUtility.Warn($"Could not refresh the Relic Coupons counter: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Uses the same native relic flash event as counting relics such as Lasting Candy. This is
+    /// shown when an earned coupon is immediately paired, even if its displayed balance stays at 0.
+    /// </summary>
+    public static void Activate(Player? player = null)
+    {
+        try
+        {
+            var relic = (player ?? GameUtility.CurrentPlayer)?.GetRelic<RelicCoupons>();
+            if (relic == null)
+                return;
+
+            TaskHelper.RunSafely(relic.DoActivateVisuals());
+        }
+        catch (Exception ex)
+        {
+            // Activation is presentation-only and must not affect coupon pairing.
+            LogUtility.Warn($"Could not activate the Relic Coupons counter: {ex.Message}");
+        }
+    }
+
+    private async Task DoActivateVisuals()
+    {
+        AssertMutable();
+        var activationSequence = ++_activationSequence;
+
+        // Pairing has already decremented the authoritative balance. Briefly show its previous
+        // value so an immediate earn-and-spend visibly ticks from 1 to 0 instead of appearing idle.
+        _activationDisplayAmount = ArchipelagoClient.Progress.BankedRelicRewards + 1;
+        InvokeCouponCountChanged();
+        Flash();
+
+        await Cmd.Wait(1f);
+        if (activationSequence != _activationSequence)
+            return;
+
+        _activationDisplayAmount = null;
+        InvokeCouponCountChanged();
+    }
+
+    private void InvokeCouponCountChanged() => InvokeDisplayAmountChanged();
+}

--- a/client/StS2AP/Models/RelicCoupons.cs
+++ b/client/StS2AP/Models/RelicCoupons.cs
@@ -24,7 +24,10 @@ public sealed class RelicCoupons : ModRelicTemplate
     private int? _activationDisplayAmount;
     private int _activationSequence;
 
-    public override RelicRarity Rarity => RelicRarity.Starter;
+    // This is AP run-state presentation, not a character starter relic. Touch of Orobas
+    // selects the first owned Starter-rarity relic, so classifying the coupon as Starter
+    // can make Touch replace it with Circlet instead of upgrading the real starter relic.
+    public override RelicRarity Rarity => RelicRarity.None;
 
     public override bool ShowCounter => true;
 

--- a/client/StS2AP/Models/RelicCoupons.cs
+++ b/client/StS2AP/Models/RelicCoupons.cs
@@ -14,6 +14,8 @@ namespace StS2AP.Models;
 /// <summary>
 /// Permanent AP-run indicator for earned natural relic rewards that have not yet been paired
 /// with a received AP Relic item. The authoritative value remains on ArchipelagoProgress.
+/// NOTE: since this is a RitsuLib relic: the appropriate relics.json localization must stay
+/// as ARCHIPELAGO to match the current ModId (even if it goes against the other localization names)
 /// </summary>
 [RegisterRelic(typeof(SharedRelicPool))]
 public sealed class RelicCoupons : ModRelicTemplate

--- a/client/StS2AP/Models/SerializableAP.cs
+++ b/client/StS2AP/Models/SerializableAP.cs
@@ -23,6 +23,12 @@ namespace StS2AP.Models
         public int RareCardRewardsAttempted { get; set; }
         [JsonPropertyName("relic_rewards_attempted")]
         public int RelicRewardsAttempted { get; set; }
+        /// <summary>Earned relic rewards not yet paired with an AP Relic receipt.</summary>
+        [JsonPropertyName("banked_relic_rewards")]
+        public int BankedRelicRewards { get; set; }
+        /// <summary>The anytime value captured when this run started.</summary>
+        [JsonPropertyName("relic_rewards_available_anytime_for_run")]
+        public int RelicRewardsAvailableAnytimeForRun { get; set; }
         [JsonPropertyName("gold_rewards_attempted")]
         public int GoldRewardsAttempted { get; set; }
         [JsonPropertyName("potion_rewards_attempted")]

--- a/client/StS2AP/Patches/Patches_AncientRelics.cs
+++ b/client/StS2AP/Patches/Patches_AncientRelics.cs
@@ -104,19 +104,12 @@ namespace StS2AP.Patches
             }
         }
 
-        private static bool IsBlocked(EventOption option)
-        {
-            return option.Relic switch
-            {
-                ArchaicTooth => ArchipelagoClient.Settings?.ProgressiveStarterCard == true,
-                TouchOfOrobas => ArchipelagoClient.Settings?.ProgressiveStarterRelic == true,
-                _ => false,
-            };
-        }
+        private static bool IsBlocked(EventOption option) =>
+            ProgressiveStarterUtility.ShouldExcludeAncientRelic(option.Relic);
 
         private static bool ShouldFilterProgressiveStarters() =>
-            ArchipelagoClient.Settings?.ProgressiveStarterCard == true ||
-            ArchipelagoClient.Settings?.ProgressiveStarterRelic == true;
+            ProgressiveStarterUtility.ShouldExcludeAncientRelic(ModelDb.Relic<ArchaicTooth>()) ||
+            ProgressiveStarterUtility.ShouldExcludeAncientRelic(ModelDb.Relic<TouchOfOrobas>());
 
         private static List<EventOption> BuildFallbackThirdPool(
             IEnumerable<EventOption> pool1,

--- a/client/StS2AP/Patches/Patches_HookRunStart.cs
+++ b/client/StS2AP/Patches/Patches_HookRunStart.cs
@@ -70,6 +70,9 @@ namespace StS2AP.Patches
                 // Reset progress
                 ArchipelagoClient.Progress.InitializeTrackers(__result);
 
+                // Relic Coupons is a presentation-only starting relic backed by the saved bank.
+                RelicCoupons.EnsureOwnedBy(__result);
+
                 // At start of game, listen to Combat Manager
                 //CombatManager.Instance.CombatWon -= GameUtility.OnCombatWin;
                 //CombatManager.Instance.CombatWon += GameUtility.OnCombatWin;

--- a/client/StS2AP/Patches/Patches_InjectAPRewards.cs
+++ b/client/StS2AP/Patches/Patches_InjectAPRewards.cs
@@ -187,6 +187,9 @@ namespace StS2AP.Patches
                 // Opening the chest is the interaction that earns this check. Sending it here
                 // avoids inserting an AP rewards screen between the chest-open animation and the
                 // native relic picker. SendCheck is idempotent for an already-checked location.
+                // The alternative was the chest opening 2 times or having to manually generate a relic
+                // I opted to use the native game default way. My rationale was that floor checks automatically send
+                // things out so what's 3 more.
                 GameUtility.SendCheck($"{player.APName()} Relic {rewardNumber}");
 
                 var relicPicker = RunManager.Instance.TreasureRoomRelicSynchronizer;
@@ -208,7 +211,10 @@ namespace StS2AP.Patches
                         ArchipelagoClient.Progress.BankedRelicRewards--;
                         RelicCoupons.RefreshCounter(player);
                         LogUtility.Error(
-                            "Could not suppress the native treasure relic; preserving vanilla without a Relic bank"
+                            """
+                            Could not suppress the native treasure relic; preserving vanilla
+                             without a Relic bank. Please notify the devs. 
+                            """
                         );
                     }
                 }
@@ -216,6 +222,7 @@ namespace StS2AP.Patches
                 {
                     // Receipts delivered after the picker was generated should not suddenly appear
                     // in the chest. They spend the new bank through the AP menu instead.
+                    // Note the logic is only sound because of the GateTreasureRelicPicker prefix
                     RelicRewardUtility.ReconcileBankedRewards(player);
                 }
             }

--- a/client/StS2AP/Patches/Patches_InjectAPRewards.cs
+++ b/client/StS2AP/Patches/Patches_InjectAPRewards.cs
@@ -154,7 +154,9 @@ namespace StS2AP.Patches
 
         /// <summary>
         /// Handles the room's base Elite relic after tutorial and extra-room rewards are assembled.
-        /// Treasure uses the same point because its native relic picker already exists by then.
+        /// Treasure uses the same point because its native relic picker already exists by then;
+        /// its AP check is sent automatically so the chest cinematic is not interrupted by a
+        /// separate rewards screen.
         /// </summary>
         [HarmonyPatch(typeof(RewardsSet), nameof(RewardsSet.WithRewardsFromRoom))]
         public static class ProcessRoomRelicReward
@@ -182,16 +184,17 @@ namespace StS2AP.Patches
                     return;
                 }
 
-                __instance.Rewards.Add(
-                    new ArchipelagoReward($"{player.APName()} Relic {rewardNumber}")
-                );
+                // Opening the chest is the interaction that earns this check. Sending it here
+                // avoids inserting an AP rewards screen between the chest-open animation and the
+                // native relic picker. SendCheck is idempotent for an already-checked location.
+                GameUtility.SendCheck($"{player.APName()} Relic {rewardNumber}");
 
                 var relicPicker = RunManager.Instance.TreasureRoomRelicSynchronizer;
                 var nativeRelicExists = relicPicker.CurrentRelics?.Count > 0;
                 if (nativeRelicExists
                     && !RelicRewardUtility.TryConsumeWaitingReceiptForNaturalReward(player))
                 {
-                    // The AP check still exists; only the native chest relic becomes a bank.
+                    // The AP check was still sent; only the native chest relic becomes a bank.
                     // BeginRelicPicking currently exposes its backing List as IReadOnlyList. Clear
                     // it here so the native empty-chest flow owns the later completion event.
                     if (relicPicker.CurrentRelics is List<RelicModel> relics)

--- a/client/StS2AP/Patches/Patches_InjectAPRewards.cs
+++ b/client/StS2AP/Patches/Patches_InjectAPRewards.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Hooks;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Relics;
 using MegaCrit.Sts2.Core.Multiplayer.Game;
 using MegaCrit.Sts2.Core.Nodes.Rewards;
 using MegaCrit.Sts2.Core.Nodes.Screens;
@@ -24,17 +25,24 @@ namespace StS2AP.Patches
     public static class Patches_InjectAPRewards
     {
 
-        private static ArchipelagoReward? GenerateForRelic(string name)
+        /// <summary>
+        /// Adds the numbered AP check for one native Elite or Black Star relic. A waiting receipt
+        /// keeps that exact reward; otherwise the reward is removed and its earned bank remains.
+        /// </summary>
+        private static void ProcessNativeRelicReward(
+            List<Reward> rewards,
+            RelicReward relicReward,
+            Player player
+        )
         {
-            // Have we already given out enough relic rewards?
-            ArchipelagoClient.Progress.RelicRewardsAttempted++;
-            if (ArchipelagoClient.Progress.RelicRewardsAttempted <= ArchipelagoProgress._maxRelicRewards)
-            {
-                // Replace this reward with an AP Location reward
-                //__result.Remove(relicReward);
-                return new ArchipelagoReward($"{name} Relic {ArchipelagoClient.Progress.RelicRewardsAttempted}");
-            }
-            return null;
+            if (!RelicRewardUtility.RecordEligibleReward(out var rewardNumber))
+                return;
+
+            rewards.Add(new ArchipelagoReward($"{player.APName()} Relic {rewardNumber}"));
+
+            // The native reward already exists. A receipt decides whether it survives beside the check.
+            if (!RelicRewardUtility.TryConsumeWaitingReceiptForNaturalReward(player))
+                rewards.Remove(relicReward);
         }
         /// <summary>
         /// Patches RewardsSet.GenerateRewardsFor to replace or inject Archipelago Location rewards.
@@ -64,18 +72,6 @@ namespace StS2AP.Patches
                 {
                     // Prepare the Character name from it's Title
                     var name = player.APName();
-
-                    // Determine if a Relic Reward is being placed
-                    var relicReward = __result.FirstOrDefault(r => r is RelicReward);
-                    if (relicReward != null)
-                    {
-                        var apReward = GenerateForRelic(name);
-                        if(apReward != null)
-                        {
-                            __result.Remove(relicReward);
-                            __result.Add(apReward);
-                        }
-                    }
 
                     // Determine if a Card Reward is being placed
                     var cardReward = __result.FirstOrDefault(r => r is CardReward);
@@ -157,6 +153,148 @@ namespace StS2AP.Patches
         }
 
         /// <summary>
+        /// Handles the room's base Elite relic after tutorial and extra-room rewards are assembled.
+        /// Treasure uses the same point because its native relic picker already exists by then.
+        /// </summary>
+        [HarmonyPatch(typeof(RewardsSet), nameof(RewardsSet.WithRewardsFromRoom))]
+        public static class ProcessRoomRelicReward
+        {
+            [HarmonyPostfix]
+            public static void Postfix(RewardsSet __instance, AbstractRoom room)
+            {
+                var player = __instance.Player;
+                if (player != GameUtility.CurrentPlayer)
+                    return;
+
+                if (room.RoomType == RoomType.Elite)
+                {
+                    // The base reward is first. Hook-added relics such as Black Star are handled
+                    // at their own append point so each one gets a separate attempt.
+                    var relicReward = __instance.Rewards.OfType<RelicReward>().FirstOrDefault();
+                    if (relicReward != null)
+                        ProcessNativeRelicReward(__instance.Rewards, relicReward, player);
+                    return;
+                }
+
+                if (room.RoomType != RoomType.Treasure
+                    || !RelicRewardUtility.RecordEligibleReward(out var rewardNumber))
+                {
+                    return;
+                }
+
+                __instance.Rewards.Add(
+                    new ArchipelagoReward($"{player.APName()} Relic {rewardNumber}")
+                );
+
+                var relicPicker = RunManager.Instance.TreasureRoomRelicSynchronizer;
+                var nativeRelicExists = relicPicker.CurrentRelics?.Count > 0;
+                if (nativeRelicExists
+                    && !RelicRewardUtility.TryConsumeWaitingReceiptForNaturalReward(player))
+                {
+                    // The AP check still exists; only the native chest relic becomes a bank.
+                    // BeginRelicPicking currently exposes its backing List as IReadOnlyList. Clear
+                    // it here so the native empty-chest flow owns the later completion event.
+                    if (relicPicker.CurrentRelics is List<RelicModel> relics)
+                    {
+                        relics.Clear();
+                    }
+                    else
+                    {
+                        // Fail open if the game changes this collection type. Do not leave a bank
+                        // behind as well as the native relic, which would duplicate the reward.
+                        ArchipelagoClient.Progress.BankedRelicRewards--;
+                        LogUtility.Error(
+                            "Could not suppress the native treasure relic; preserving vanilla without a Relic bank"
+                        );
+                    }
+                }
+                else if (!nativeRelicExists)
+                {
+                    // Receipts delivered after the picker was generated should not suddenly appear
+                    // in the chest. They spend the new bank through the AP menu instead.
+                    RelicRewardUtility.ReconcileBankedRewards(player);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decides chest ownership before the native picker pulls from its relic bag. If no receipt
+        /// is waiting, leave an empty picker for the AP check and bank recorded when the chest opens.
+        /// </summary>
+        [HarmonyPatch(
+            typeof(TreasureRoomRelicSynchronizer),
+            nameof(TreasureRoomRelicSynchronizer.BeginRelicPicking)
+        )]
+        public static class GateTreasureRelicPicker
+        {
+            [HarmonyPrefix]
+            public static bool Prefix(
+                ref List<RelicModel> ____currentRelics,
+                ref PlayerVote ____predictedVote
+            )
+            {
+                if (____currentRelics != null)
+                {
+                    throw new InvalidOperationException(
+                        "Attempted to start new relic picking session while one was already occurring!"
+                    );
+                }
+
+                var player = GameUtility.CurrentPlayer;
+                if (player == null
+                    || ArchipelagoClient.Progress.RelicRewardsAttempted
+                        >= ArchipelagoProgress._maxRelicRewards
+                    || RelicRewardUtility.HasWaitingReceiptForNaturalReward(player))
+                {
+                    return true;
+                }
+
+                ____currentRelics = new List<RelicModel>();
+                ____predictedVote = new PlayerVote
+                {
+                    voteReceived = true,
+                    index = 0,
+                };
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Black Star appends its own native reward during reward hooks. Process only that new
+        /// reward so it stays independent from the base Elite relic and receives its own AP check.
+        /// </summary>
+        [HarmonyPatch(typeof(BlackStar), nameof(BlackStar.TryModifyRewards))]
+        public static class ProcessBlackStarRelicReward
+        {
+            [HarmonyPrefix]
+            public static void Prefix(List<Reward> rewards, out int __state)
+            {
+                __state = rewards.Count;
+            }
+
+            [HarmonyPostfix]
+            public static void Postfix(
+                Player player,
+                List<Reward> rewards,
+                AbstractRoom? room,
+                bool __result,
+                int __state
+            )
+            {
+                if (!__result
+                    || player != GameUtility.CurrentPlayer
+                    || room?.RoomType != RoomType.Elite)
+                {
+                    return;
+                }
+
+                var relicReward = rewards.Skip(__state).OfType<RelicReward>().FirstOrDefault();
+                if (relicReward != null)
+                    ProcessNativeRelicReward(rewards, relicReward, player);
+            }
+        }
+
+        /// <summary>
         /// When an AP Location reward has already been claimed, make it semi-transparent in the rewards screen to indicate that it's been claimed.
         /// </summary>
         [HarmonyPatch(typeof(NRewardsScreen), "ShowScreen")]
@@ -199,54 +337,5 @@ namespace StS2AP.Patches
             }
         }
 
-        /// <summary>
-        /// Prevents chests from giving relics if that list hasn't been exhausted.
-        /// </summary>
-        [HarmonyPatch(typeof(TreasureRoomRelicSynchronizer), nameof(TreasureRoomRelicSynchronizer.BeginRelicPicking))]
-        public static class PreventRelicsFromChests
-        {
-            [HarmonyPrefix]
-            public static bool Prefix(ref List<RelicModel> ____currentRelics, ref PlayerVote ____predictedVote)
-            {
-                if(____currentRelics != null)
-                {
-			        throw new InvalidOperationException("Attempted to start new relic picking session while one was already occurring!");
-                }
-
-                if(ArchipelagoClient.Progress.RelicChoiceAssignments.Count < ArchipelagoProgress._maxRelicRewards)
-                {
-                    ____currentRelics = new List<RelicModel>();
-                    ____predictedVote = new PlayerVote()
-                    {
-                        voteReceived    = true,     
-                        index = 0
-                    };
-                    return false;
-                }
-
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Adds an AP Relic reward, if appropriate
-        /// </summary>
-        [HarmonyPatch(typeof(RewardsSet), nameof(RewardsSet.WithRewardsFromRoom))]
-        public static class InjectAPRewardsForChest
-        {
-            [HarmonyPostfix]
-            public static void Postfix(RewardsSet __instance, AbstractRoom room)
-            {
-                if(room.RoomType != RoomType.Treasure)
-                {
-                    return;
-                }
-                var apReward = GenerateForRelic(__instance.Player.APName());
-                if(apReward != null)
-                {
-                    __instance.Rewards.Add(apReward);
-                }
-            }
-        }
     }
 }

--- a/client/StS2AP/Patches/Patches_InjectAPRewards.cs
+++ b/client/StS2AP/Patches/Patches_InjectAPRewards.cs
@@ -206,6 +206,7 @@ namespace StS2AP.Patches
                         // Fail open if the game changes this collection type. Do not leave a bank
                         // behind as well as the native relic, which would duplicate the reward.
                         ArchipelagoClient.Progress.BankedRelicRewards--;
+                        RelicCoupons.RefreshCounter(player);
                         LogUtility.Error(
                             "Could not suppress the native treasure relic; preserving vanilla without a Relic bank"
                         );

--- a/client/StS2AP/Patches/Patches_SaveManagement.cs
+++ b/client/StS2AP/Patches/Patches_SaveManagement.cs
@@ -232,6 +232,7 @@ namespace StS2AP.Patches
                         GameUtility.CurrentConfig = ArchipelagoClient.Settings.Characters[GameUtility.CurrentPlayer.getInternalName()];
                         ArchipelagoClient.Progress = ArchipelagoProgress.FromSerializable(result, GameUtility.CurrentPlayer);
                         ArchipelagoClient.ReprocessItems();
+                        RelicRewardUtility.ReconcileBankedRewards(GameUtility.CurrentPlayer);
                         ArchipelagoClient.Progress.InitializeFromServer(GameUtility.CurrentPlayer);
                         await NGame.Instance.Transition.FadeOut(0.8f, runState.Players[0].Character.CharacterSelectTransitionPath);
                         NGame.Instance.ReactionContainer.InitializeNetworking(new NetSingleplayerGameService());

--- a/client/StS2AP/Patches/Patches_SaveManagement.cs
+++ b/client/StS2AP/Patches/Patches_SaveManagement.cs
@@ -231,6 +231,7 @@ namespace StS2AP.Patches
                         GameUtility.CurrentPlayer = runState.Players[0];
                         GameUtility.CurrentConfig = ArchipelagoClient.Settings.Characters[GameUtility.CurrentPlayer.getInternalName()];
                         ArchipelagoClient.Progress = ArchipelagoProgress.FromSerializable(result, GameUtility.CurrentPlayer);
+                        RelicCoupons.EnsureOwnedBy(GameUtility.CurrentPlayer, silent: true);
                         ArchipelagoClient.ReprocessItems();
                         RelicRewardUtility.ReconcileBankedRewards(GameUtility.CurrentPlayer);
                         ArchipelagoClient.Progress.InitializeFromServer(GameUtility.CurrentPlayer);
@@ -314,6 +315,7 @@ namespace StS2AP.Patches
                     SfxCmd.Play(runState.Players[0].Character.CharacterTransitionSfx);
 
                     GameUtility.CurrentPlayer = runState.Players[0];
+                    RelicCoupons.EnsureOwnedBy(GameUtility.CurrentPlayer, silent: true);
 
                     await NGame.Instance.Transition.FadeOut(0.8f, runState.Players[0].Character.CharacterSelectTransitionPath);
                     NGame.Instance.ReactionContainer.InitializeNetworking(new NetSingleplayerGameService());

--- a/client/StS2AP/UI/ArchipelagoRewardUI.cs
+++ b/client/StS2AP/UI/ArchipelagoRewardUI.cs
@@ -391,10 +391,20 @@ namespace StS2AP.UI
             var currentPlayer = GameUtility.CurrentPlayer;
             if (currentPlayer == null) return;
 
+            // Normally this happens on receipt or checkpoint load. Retrying here keeps an
+            // unexpected assignment failure recoverable without another tracking state.
+            RelicRewardUtility.ReconcileBankedRewards(currentPlayer);
 
             // Get Unused items from the Multiworld for our current character
             var availableItems = ArchipelagoClient.Progress.AllReceivedItems
-                                .Where(i => !ArchipelagoClient.Progress.UsedItems.Contains(i.Index) && i.Item.GetCharacterOffset() == GameUtility.CurrentCharacterID);
+                .Where(i =>
+                    !ArchipelagoClient.Progress.UsedItems.Contains(i.Index)
+                    && i.Item.GetCharacterOffset() == GameUtility.CurrentCharacterID
+                )
+                .Where(i =>
+                    i.Item.GetCharacterSpecificItemID() != APItem.Relic
+                    || RelicRewardUtility.IsAvailableInRewardMenu(i, currentPlayer)
+                );
             
             // Prepare them for the UI
             var rewardDataList = availableItems.Where(i => i.Item.GetCharacterSpecificItemID().CanBePickedUp()).Select(i =>
@@ -415,12 +425,18 @@ namespace StS2AP.UI
                 var rawId = i.Item.GetCharacterSpecificItemID();
                 if (rawId == APItem.Relic)
                 {
-                    var choiceCount = ArchipelagoClient.Settings?.RelicChoiceCount ?? 1;
-                    var choices = ArchipelagoClient.Progress.GetOrAssignRelicChoices(i.Index, currentPlayer, choiceCount);
+                    // AP-menu Relics are deliberately one persisted choice. Normal-screen relics
+                    // stay native and never enter this assignment map.
+                    var choices = ArchipelagoClient.Progress.GetOrAssignRelicChoices(
+                        i.Index,
+                        currentPlayer,
+                        choiceCount: 1
+                    );
                     if (choices.Count > 0)
                     {
                         data.ItemName = "Choose a Relic";
                         data.LinkedRelicChoices = choices;
+                        data.OnClaimed = () => RelicRewardUtility.CompleteMenuClaim(i.Index);
                     }
                     else
                     {
@@ -475,7 +491,7 @@ namespace StS2AP.UI
                 return data;
             }).ToList();
 
-            rewardDataList.ForEach(item => item.OnClaimed = () =>
+            rewardDataList.ForEach(item => item.OnClaimed ??= () =>
             {
                 // Mark the item as used in the Multiworld so it doesn't show up again if we reopen the screen
                 ArchipelagoClient.Progress.UsedItems.Add(item.Index);
@@ -941,7 +957,7 @@ namespace StS2AP.UI
                         group.QueueFree();
                         _remainingRewards--;
                         UpdateProceedButton();
-                        ArchipelagoTopBarUI.SetCount(ArchipelagoClient.Progress.UnusedItemCount);
+                        ArchipelagoTopBarUI.RefreshCount();
 
                         if (_remainingRewards <= 0)
                             Hide();

--- a/client/StS2AP/UI/RelicRewardDebugUI.cs
+++ b/client/StS2AP/UI/RelicRewardDebugUI.cs
@@ -1,0 +1,129 @@
+using Godot;
+using StS2AP.Utils;
+
+namespace StS2AP.UI
+{
+    /// <summary>
+    /// Opt-in developer overlay for inspecting progressive Relic receipt/bank state in real time.
+    /// Toggle it from the developer console with <c>aprelicdebug</c>.
+    /// </summary>
+    public static class RelicRewardDebugUI
+    {
+        private static CanvasLayer? _canvasLayer;
+        private static Label? _counterLabel;
+        private static Godot.Timer? _refreshTimer;
+
+        private const string FontPath = "res://fonts/kreon_regular.ttf";
+        private const int CanvasLayerIndex = 100;
+        private const int FontSize = 22;
+        private const int OutlineSize = 6;
+        private const double RefreshIntervalSeconds = 0.1;
+
+        private static readonly Color TextColor = new Color(0.65f, 1.0f, 0.65f);
+
+        public static bool IsVisible =>
+            _canvasLayer != null
+            && GodotObject.IsInstanceValid(_canvasLayer)
+            && _canvasLayer.Visible;
+
+        public static void Show()
+        {
+            try
+            {
+                if (_canvasLayer != null && GodotObject.IsInstanceValid(_canvasLayer))
+                {
+                    _canvasLayer.Visible = true;
+                    Refresh();
+                    return;
+                }
+
+                var sceneTree = Engine.GetMainLoop() as SceneTree;
+                var root = sceneTree?.Root;
+                if (root == null)
+                {
+                    LogUtility.Error("[RelicDebug] Could not find the scene root");
+                    return;
+                }
+
+                _canvasLayer = new CanvasLayer
+                {
+                    Name = "APRelicRewardDebugLayer",
+                    Layer = CanvasLayerIndex,
+                };
+
+                _counterLabel = new Label
+                {
+                    Name = "APRelicRewardDebugCounters",
+                    Position = new Vector2(24f, 160f),
+                    Size = new Vector2(420f, 120f),
+                    MouseFilter = Control.MouseFilterEnum.Ignore,
+                };
+                _counterLabel.AddThemeColorOverride("font_color", TextColor);
+                _counterLabel.AddThemeColorOverride("font_outline_color", Colors.Black);
+                _counterLabel.AddThemeFontSizeOverride("font_size", FontSize);
+                _counterLabel.AddThemeConstantOverride("outline_size", OutlineSize);
+
+                try
+                {
+                    var font = GD.Load<Font>(FontPath);
+                    if (font != null)
+                        _counterLabel.AddThemeFontOverride("font", font);
+                }
+                catch (Exception ex)
+                {
+                    LogUtility.Warn($"[RelicDebug] Could not load font: {ex.Message}");
+                }
+
+                _refreshTimer = new Godot.Timer
+                {
+                    Name = "APRelicRewardDebugRefreshTimer",
+                    WaitTime = RefreshIntervalSeconds,
+                    OneShot = false,
+                    Autostart = true,
+                };
+                _refreshTimer.Timeout += Refresh;
+
+                _canvasLayer.AddChild(_counterLabel);
+                _canvasLayer.AddChild(_refreshTimer);
+                root.AddChild(_canvasLayer);
+                Refresh();
+            }
+            catch (Exception ex)
+            {
+                LogUtility.Error($"[RelicDebug] Could not show overlay: {ex}");
+                Hide();
+            }
+        }
+
+        public static void Hide()
+        {
+            if (_canvasLayer != null && GodotObject.IsInstanceValid(_canvasLayer))
+                _canvasLayer.QueueFree();
+
+            _canvasLayer = null;
+            _counterLabel = null;
+            _refreshTimer = null;
+        }
+
+        private static void Refresh()
+        {
+            if (_counterLabel == null || !GodotObject.IsInstanceValid(_counterLabel))
+                return;
+
+            var player = GameUtility.CurrentPlayer;
+            var receiptCount = player == null
+                ? 0
+                : RelicRewardUtility.CountWaitingReceiptsForNaturalReward(player);
+            var receivedCount = player == null
+                ? 0
+                : RelicRewardUtility.CountReceivedRelics(player);
+            var progress = ArchipelagoClient.Progress;
+
+            _counterLabel.Text =
+                $"Relic receipts waiting: {receiptCount}\n" +
+                $"Banked relics: {progress.BankedRelicRewards}\n" +
+                $"Relic reward attempts: {progress.RelicRewardsAttempted}\n" +
+                $"Relics received: {receivedCount}";
+        }
+    }
+}

--- a/client/StS2AP/Utils/APDevCommand.cs
+++ b/client/StS2AP/Utils/APDevCommand.cs
@@ -1,6 +1,7 @@
 ﻿using MegaCrit.Sts2.Core.DevConsole;
 using MegaCrit.Sts2.Core.DevConsole.ConsoleCommands;
 using MegaCrit.Sts2.Core.Entities.Players;
+using StS2AP.UI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,6 +34,54 @@ namespace StS2AP.Utils
             }
             ArchipelagoClient.Session.Say(sendMe);
             return new CmdResult(true);
+        }
+    }
+
+    /// <summary>
+    /// Toggles the live counters used to debug progressive Relic receipt/bank behavior.
+    /// </summary>
+    public class APRelicDebugCommand : AbstractConsoleCmd
+    {
+        public override string CmdName => "aprelicdebug";
+
+        public override string Args => "[on|off]";
+
+        public override string Description => "Toggles the AP Relic receipt/bank debug overlay";
+
+        public override bool IsNetworked => false;
+
+        public override CmdResult Process(Player? issuingPlayer, string[] args)
+        {
+            bool shouldShow;
+            if (args.Length == 0)
+            {
+                shouldShow = !RelicRewardDebugUI.IsVisible;
+            }
+            else if (args.Length == 1 && args[0].Equals("on", StringComparison.OrdinalIgnoreCase))
+            {
+                shouldShow = true;
+            }
+            else if (args.Length == 1 && args[0].Equals("off", StringComparison.OrdinalIgnoreCase))
+            {
+                shouldShow = false;
+            }
+            else
+            {
+                return new CmdResult(false, "Usage: aprelicdebug [on|off]");
+            }
+
+            if (shouldShow)
+                RelicRewardDebugUI.Show();
+            else
+                RelicRewardDebugUI.Hide();
+
+            if (shouldShow && !RelicRewardDebugUI.IsVisible)
+                return new CmdResult(false, "Could not create the AP Relic debug overlay; check the log.");
+
+            return new CmdResult(
+                true,
+                $"AP Relic debug overlay {(RelicRewardDebugUI.IsVisible ? "enabled" : "disabled")}."
+            );
         }
     }
 }

--- a/client/StS2AP/Utils/AncientRelicPool.cs
+++ b/client/StS2AP/Utils/AncientRelicPool.cs
@@ -27,6 +27,9 @@ namespace StS2AP.Utils
         private static bool IsBlacklisted(RelicModel relic) =>
             BlacklistedRelicTypes.Any(type => type.IsInstanceOfType(relic));
 
+        private static bool IsExcluded(RelicModel relic) =>
+            IsBlacklisted(relic) || ProgressiveStarterUtility.ShouldExcludeAncientRelic(relic);
+
         /// <summary>
         /// Selects a stable set of three relics for a reward key without consuming the game's RNG.
         /// </summary>
@@ -248,7 +251,7 @@ namespace StS2AP.Utils
                         // TODO: do model selection in a better way than this
                         if (relic.Id == ModelId.none ||
                             ownedOrReservedRelicIds.Contains(relic.Id) ||
-                            IsBlacklisted(relic))
+                            IsExcluded(relic))
                         {
                             continue;
                         }

--- a/client/StS2AP/Utils/GameUtility.cs
+++ b/client/StS2AP/Utils/GameUtility.cs
@@ -631,11 +631,20 @@ namespace StS2AP.Utils
 
                     LogUtility.Success($"TrySetGoalAchieved: Recorded goal for '{charName}'. Total goaled: {_goaledCharacters.Count}");
 
-                    // Now that the character has cleared, we should release all of their checks
-                    await TryReleaseAllCharacterChecks(CurrentPlayer.APName());
-                    foreach(var unrecognized in ArchipelagoClient.Settings.UnrecognizedCharacters.Values)
+                    // Goal progress is independent from whether victory releases this character's checks.
+                    if (settings.ReleaseOnVictory)
                     {
-                        await TryReleaseAllCharacterChecks(unrecognized.Name);
+                        await TryReleaseAllCharacterChecks(CurrentPlayer.APName());
+                        foreach(var unrecognized in ArchipelagoClient.Settings.UnrecognizedCharacters.Values)
+                        {
+                            await TryReleaseAllCharacterChecks(unrecognized.Name);
+                        }
+                    }
+                    else
+                    {
+                        LogUtility.Info(
+                            $"Victory recorded for '{charName}' without releasing remaining checks"
+                        );
                     }
                 }
                 else

--- a/client/StS2AP/Utils/ProgressiveStarterUtility.cs
+++ b/client/StS2AP/Utils/ProgressiveStarterUtility.cs
@@ -22,6 +22,20 @@ namespace StS2AP.Utils
         private static readonly SemaphoreSlim ReconcileLock = new(1, 1);
 
         /// <summary>
+        /// Returns whether an Ancient relic is reserved for AP's progressive starter tiers and
+        /// therefore must not be offered by either the natural Ancient or an AP-built pool.
+        /// </summary>
+        internal static bool ShouldExcludeAncientRelic(RelicModel? relic)
+        {
+            return relic switch
+            {
+                ArchaicTooth => ArchipelagoClient.Settings?.ProgressiveStarterCard == true,
+                TouchOfOrobas => ArchipelagoClient.Settings?.ProgressiveStarterRelic == true,
+                _ => false,
+            };
+        }
+
+        /// <summary>
         /// Captures supported starter identities while the vanilla starting deck and relics are
         /// still present, then applies the tier already received from Archipelago.
         /// </summary>

--- a/client/StS2AP/Utils/RelicRewardUtility.cs
+++ b/client/StS2AP/Utils/RelicRewardUtility.cs
@@ -44,6 +44,7 @@ namespace StS2AP.Utils
                 return false;
 
             progress.BankedRelicRewards++;
+            RelicCoupons.RefreshCounter();
             return true;
         }
 
@@ -101,6 +102,7 @@ namespace StS2AP.Utils
 
             progress.UsedItems.Add(receipt.Index);
             progress.BankedRelicRewards--;
+            RelicCoupons.Activate(player);
             LogUtility.Info(
                 $"Paired Relic item w/ index {receipt.Index} with a natural relic reward; " +
                 $"{progress.BankedRelicRewards} banked reward(s) remain"
@@ -138,6 +140,7 @@ namespace StS2AP.Utils
                 }
 
                 progress.BankedRelicRewards--;
+                RelicCoupons.Activate(player);
                 LogUtility.Info(
                     $"Assigned banked relic reward to AP item w/ index {receipt.Index}; " +
                     $"{progress.BankedRelicRewards} banked reward(s) remain"

--- a/client/StS2AP/Utils/RelicRewardUtility.cs
+++ b/client/StS2AP/Utils/RelicRewardUtility.cs
@@ -1,0 +1,217 @@
+using MegaCrit.Sts2.Core.Entities.Players;
+using StS2AP.Extensions;
+using StS2AP.Models;
+using static StS2AP.Data.ItemTable;
+
+namespace StS2AP.Utils
+{
+    /// <summary>
+    /// Coordinates AP Relic receipts with the first ten eligible Elite, treasure, and Black Star
+    /// rewards in a run. The first configured receipts are available immediately; later receipts
+    /// must be paired with an earned natural relic reward.
+    /// </summary>
+    public static class RelicRewardUtility
+    {
+        /// <summary>
+        /// The anytime value that should be captured when a new run starts. A local override wins
+        /// over slot data, and the result is kept within the number of Relic checks in a run.
+        /// </summary>
+        public static int EffectiveAvailableAnytime
+        {
+            get
+            {
+                var localSettings = ArchipelagoClient.LocalSettings.Value;
+                var configuredValue = localSettings.OverrideRelicRewardsAvailableAnytime
+                    ? localSettings.RelicRewardsAvailableAnytime
+                    : ArchipelagoClient.Settings?.RelicRewardsAvailableAnytime
+                        ?? localSettings.RelicRewardsAvailableAnytime;
+
+                return Math.Clamp(configuredValue, 0, ArchipelagoProgress._maxRelicRewards);
+            }
+        }
+
+        /// <summary>
+        /// Records one eligible natural relic source. Every attempt is counted, but only the first
+        /// ten create an AP check and a bank that can be paired with a Relic receipt.
+        /// </summary>
+        public static bool RecordEligibleReward(out int rewardNumber)
+        {
+            var progress = ArchipelagoClient.Progress;
+            progress.RelicRewardsAttempted++;
+            rewardNumber = progress.RelicRewardsAttempted;
+
+            if (rewardNumber > ArchipelagoProgress._maxRelicRewards)
+                return false;
+
+            progress.BankedRelicRewards++;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns whether a gated Relic receipt is waiting for a natural relic source.
+        /// </summary>
+        public static bool HasWaitingReceiptForNaturalReward(Player player)
+        {
+            return FindWaitingReceiptForNaturalReward(player) != null;
+        }
+
+        /// <summary>
+        /// Returns the number of gated Relic receipts still waiting for a natural relic source.
+        /// Used by the opt-in relic debug overlay.
+        /// </summary>
+        public static int CountWaitingReceiptsForNaturalReward(Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            return GetRelicReceipts(player)
+                .Skip(GetAvailableAnytimeForRun())
+                .Count(receipt =>
+                    !progress.UsedItems.Contains(receipt.Index)
+                    && !progress.RelicChoiceAssignments.ContainsKey(receipt.Index)
+                );
+        }
+
+        /// <summary>
+        /// Returns every AP Relic receipt received for the current character, including anytime,
+        /// waiting, assigned, and already-consumed receipts.
+        /// </summary>
+        public static int CountReceivedRelics(Player player)
+        {
+            return GetRelicReceipts(player).Count();
+        }
+
+        /// <summary>
+        /// Pairs the newly recorded bank with the oldest waiting gated receipt. The AP item is
+        /// consumed immediately because the native reward screen now owns the relic grant.
+        /// </summary>
+        public static bool TryConsumeWaitingReceiptForNaturalReward(Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            var receipt = FindWaitingReceiptForNaturalReward(player);
+            if (receipt == null)
+                return false;
+
+            if (progress.BankedRelicRewards <= 0)
+            {
+                LogUtility.Error(
+                    $"Cannot pair Relic item w/ index {receipt.Index} for {player.APName()}: " +
+                    "no banked relic reward exists"
+                );
+                return false;
+            }
+
+            progress.UsedItems.Add(receipt.Index);
+            progress.BankedRelicRewards--;
+            LogUtility.Info(
+                $"Paired Relic item w/ index {receipt.Index} with a natural relic reward; " +
+                $"{progress.BankedRelicRewards} banked reward(s) remain"
+            );
+            return true;
+        }
+
+        /// <summary>
+        /// Pairs older earned banks with waiting gated receipts for display in the AP reward menu.
+        /// The assignment is persisted before the bank is spent, so reopening or loading cannot
+        /// reroll the offered relic. The value remains a list to support multiple choices later.
+        /// </summary>
+        public static void ReconcileBankedRewards(Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            while (progress.BankedRelicRewards > 0)
+            {
+                var receipt = FindWaitingReceiptForNaturalReward(player);
+                if (receipt == null)
+                    return;
+
+                var choices = progress.GetOrAssignRelicChoices(
+                    receipt.Index,
+                    player,
+                    choiceCount: 1
+                );
+                if (choices.Count != 1)
+                {
+                    LogUtility.Error(
+                        $"Could not pair banked relic reward with AP item w/ index {receipt.Index} " +
+                        $"for {player.APName()}; " +
+                        "leaving both available for retry"
+                    );
+                    return;
+                }
+
+                progress.BankedRelicRewards--;
+                LogUtility.Info(
+                    $"Assigned banked relic reward to AP item w/ index {receipt.Index}; " +
+                    $"{progress.BankedRelicRewards} banked reward(s) remain"
+                );
+            }
+        }
+
+        /// <summary>
+        /// Returns whether this Relic receipt belongs in the AP reward menu. Receipts are available
+        /// there when they are among the run's first X or have a persisted banked assignment.
+        /// </summary>
+        public static bool IsAvailableInRewardMenu(IndexedItemInfo receipt, Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            if (progress.UsedItems.Contains(receipt.Index)
+                || receipt.Item.GetCharacterSpecificItemID() != APItem.Relic
+                || receipt.Item.GetCharacterOffset() != player.Character.GetCharacterOffset())
+            {
+                return false;
+            }
+
+            return IsAnytimeReceipt(receipt, player)
+                || progress.RelicChoiceAssignments.ContainsKey(receipt.Index);
+        }
+
+        /// <summary>
+        /// Completes a relic claimed through the AP reward menu and releases its persisted choice.
+        /// The bank, when one was required, was already spent when this assignment was created.
+        /// </summary>
+        public static void CompleteMenuClaim(int itemIndex)
+        {
+            var progress = ArchipelagoClient.Progress;
+            if (!progress.UsedItems.Contains(itemIndex))
+                progress.UsedItems.Add(itemIndex);
+
+            progress.RelicChoiceAssignments.Remove(itemIndex);
+        }
+
+        private static IndexedItemInfo? FindWaitingReceiptForNaturalReward(Player player)
+        {
+            var progress = ArchipelagoClient.Progress;
+            return GetRelicReceipts(player)
+                .Skip(GetAvailableAnytimeForRun())
+                .FirstOrDefault(receipt =>
+                    !progress.UsedItems.Contains(receipt.Index)
+                    && !progress.RelicChoiceAssignments.ContainsKey(receipt.Index)
+                );
+        }
+
+        private static bool IsAnytimeReceipt(IndexedItemInfo receipt, Player player)
+        {
+            return GetRelicReceipts(player)
+                .Take(GetAvailableAnytimeForRun())
+                .Any(candidate => candidate.Index == receipt.Index);
+        }
+
+        private static IEnumerable<IndexedItemInfo> GetRelicReceipts(Player player)
+        {
+            var characterOffset = player.Character.GetCharacterOffset();
+            return ArchipelagoClient.Progress.AllReceivedItems
+                .Where(receipt =>
+                    receipt.Item.GetCharacterOffset() == characterOffset
+                    && receipt.Item.GetCharacterSpecificItemID() == APItem.Relic
+                )
+                .OrderBy(receipt => receipt.Index);
+        }
+
+        private static int GetAvailableAnytimeForRun()
+        {
+            return Math.Clamp(
+                ArchipelagoClient.Progress.RelicRewardsAvailableAnytimeForRun,
+                0,
+                ArchipelagoProgress._maxRelicRewards
+            );
+        }
+    }
+}

--- a/client/StS2AP/Utils/RelicRewardUtility.cs
+++ b/client/StS2AP/Utils/RelicRewardUtility.cs
@@ -83,6 +83,7 @@ namespace StS2AP.Utils
         /// <summary>
         /// Pairs the newly recorded bank with the oldest waiting gated receipt. The AP item is
         /// consumed immediately because the native reward screen now owns the relic grant.
+        /// Returns true if it succeeded consuming a receipt.
         /// </summary>
         public static bool TryConsumeWaitingReceiptForNaturalReward(Player player)
         {

--- a/client/StS2AP/godot/Archipelago/localization/eng/relics.json
+++ b/client/StS2AP/godot/Archipelago/localization/eng/relics.json
@@ -1,0 +1,5 @@
+{
+  "ARCHIPELAGO_RELIC_RELIC_COUPONS.title": "Relic Coupons",
+  "ARCHIPELAGO_RELIC_RELIC_COUPONS.description": "Earn Relic Coupons from Elites and Treasure Chests. Each coupon is paired with an Archipelago Relic item, granting its relic through naturally or via the Archipelago rewards menu.",
+  "ARCHIPELAGO_RELIC_RELIC_COUPONS.flavor": "A promise that somewhere in the multiworld, a relic is waiting for you."
+}

--- a/world/spire2/options.py
+++ b/world/spire2/options.py
@@ -149,14 +149,20 @@ class AncientRelicPool(Choice):
     default = 0
 
 
-class RelicChoiceCount(Range):
-    """How many relics you can choose from when claiming a Relic received from Archipelago.
+class RelicRewardsAvailableAnytime(Range):
+    """How many Relic items can be claimed before earning relic rewards in the run.
 
-    This affects only Relic items received from Archipelago. Relics offered by the base game
-    and other mods are unchanged."""
-    display_name = "Relic Choice Count"
-    range_start = 1
-    range_end = 5
+    The client snapshots this value at run start. Later Relic items need a reward from an
+    Elite, treasure chest, or Black Star before they appear in the AP reward menu."""
+    display_name = "Relic Rewards Available Anytime"
+    range_start = 0
+    range_end = 10
+    default = 2
+
+
+class ReleaseOnVictory(Toggle):
+    """Release the winning character's remaining checks when their goal is recorded."""
+    display_name = "Release Checks On Victory"
     default = 1
 
 
@@ -593,7 +599,8 @@ class Spire2Options(PerGameCommonOptions):
     ascension_down: AscensionDown
     ancient_relic_location: AncientRelicLocation
     ancient_relic_pool: AncientRelicPool
-    relic_choice_count: RelicChoiceCount
+    relic_rewards_available_anytime: RelicRewardsAvailableAnytime
+    release_on_victory: ReleaseOnVictory
     shuffle_all_cards: CardReward
     include_floor_checks: IncludeFloorChecks
     # Filler item weights

--- a/world/spire2/test/option_tests.py
+++ b/world/spire2/test/option_tests.py
@@ -81,20 +81,27 @@ class TestAncientRelicOptionsTrueChaos(Spire2TestBase):
         self.assertEqual(2, self.world.fill_slot_data()["ancient_relic_pool"])
 
 
-class TestRelicChoiceCountDefault(Spire2TestBase):
-    def test_one_choice_by_default(self):
-        self.assertEqual(1, self.world.options.relic_choice_count.value)
-        self.assertEqual(1, self.world.fill_slot_data()["relic_choice_count"])
+class TestProgressiveRelicOptionsDefault(Spire2TestBase):
+    def test_defaults_are_sent_in_slot_data(self):
+        slot_data = self.world.fill_slot_data()
+        self.assertEqual(2, self.world.options.relic_rewards_available_anytime.value)
+        self.assertEqual(2, slot_data["relic_rewards_available_anytime"])
+        self.assertEqual(1, self.world.options.release_on_victory.value)
+        self.assertEqual(1, slot_data["release_on_victory"])
 
 
-class TestRelicChoiceCountConfigured(Spire2TestBase):
+class TestProgressiveRelicOptionsConfigured(Spire2TestBase):
     options = {
-        "relic_choice_count": 5,
+        "relic_rewards_available_anytime": 7,
+        "release_on_victory": 0,
     }
 
-    def test_configured_count_is_sent_in_slot_data(self):
-        self.assertEqual(5, self.world.options.relic_choice_count.value)
-        self.assertEqual(5, self.world.fill_slot_data()["relic_choice_count"])
+    def test_configured_values_are_sent_in_slot_data(self):
+        slot_data = self.world.fill_slot_data()
+        self.assertEqual(7, self.world.options.relic_rewards_available_anytime.value)
+        self.assertEqual(7, slot_data["relic_rewards_available_anytime"])
+        self.assertEqual(0, self.world.options.release_on_victory.value)
+        self.assertEqual(0, slot_data["release_on_victory"])
 
 
 class TestAscensionDowns(Spire2TestBase):

--- a/world/spire2/web_world.py
+++ b/world/spire2/web_world.py
@@ -5,7 +5,7 @@ from .options import (
     Characters, DeathLinkDamagePercent, EnableDeathFragments, PickNumberCharacters, GoalNumChar,
     LockCharacters, UnlockedCharacter, Ascension,
     IncludeFloorChecks, CampfireSanity, GoldSanity, PotionSanity,
-    AncientRelicLocation, AncientRelicPool, RelicChoiceCount,
+    AncientRelicLocation, AncientRelicPool, RelicRewardsAvailableAnytime, ReleaseOnVictory,
     CardReward, ProgressiveStarterCard, ProgressiveStarterRelic,
     OneGoldFillerWeight, FiveGoldFillerWeight,
     FreeAttackFillerWeight, FreePowerFillerWeight, FreeSkillFillerWeight,
@@ -39,7 +39,8 @@ class SlayTheSpire2Web(WebWorld):
         OptionGroup("Game Options", [
             AncientRelicLocation,
             AncientRelicPool,
-            RelicChoiceCount,
+            RelicRewardsAvailableAnytime,
+            ReleaseOnVictory,
         ]),
         OptionGroup("Sanities", [
             IncludeFloorChecks,

--- a/world/spire2/world.py
+++ b/world/spire2/world.py
@@ -687,7 +687,8 @@ class SlayTheSpire2World(World):
             "neow_sanity",
             "ancient_relic_location",
             "ancient_relic_pool",
-            "relic_choice_count",
+            "relic_rewards_available_anytime",
+            "release_on_victory",
             "shop_sanity",
             "potion_sanity",
             "gold_sanity",
@@ -732,7 +733,8 @@ class SlayTheSpire2World(World):
         self.options.neow_sanity.value = slot_data['neow_sanity']
         self.options.ancient_relic_location.value = slot_data['ancient_relic_location']
         self.options.ancient_relic_pool.value = slot_data['ancient_relic_pool']
-        self.options.relic_choice_count.value = slot_data['relic_choice_count']
+        self.options.relic_rewards_available_anytime.value = slot_data['relic_rewards_available_anytime']
+        self.options.release_on_victory.value = slot_data['release_on_victory']
         self.options.campfire_sanity.value = slot_data['campfire_sanity']
         self.options.progressive_starter_card.value = slot_data['progressive_starter_card']
         self.options.progressive_starter_relic.value = slot_data['progressive_starter_relic']


### PR DESCRIPTION
### Key Changes
- RelicCoupons keeps track of how many natural relics are banked. You need both RelicCoupons and an AP relic in order to claim a relic from an elite/chest. Fighting elites first and then getting sent an AP relic will instead put the relic in the menu. This makes elites always worth fighting. If the relics weren't banked then you could fight 8 elites but then later get 5 AP relics but you're at Mid Act 3 but you wouldn't actually be able to claim them
- Relic Coupons relic 
- Your first X (default 2) relics are available from the AP reward menu without fighting elites or going to chests. This is to give some front load to players.
- Add client Side setting to ignore the value from the yaml and instead use your own. This is to allow people to make the run easier/harder as they see fit. 
- Add option to prevent releasing all of the character's checks upon beating a run. Useful for 100% no release runs and people were requesting this
- Fixed some bugs where Touch of Orobas and Archaic Tooth were being offered with Progressive Starter Items on.